### PR TITLE
RC-17937:genentech issue with template file generating values.yaml

### DIFF
--- a/rafay/structure_artifact.go
+++ b/rafay/structure_artifact.go
@@ -98,10 +98,7 @@ func ExpandArtifact(artifactType string, ap []interface{}) (*commonpb.ArtifactSp
 		}
 
 		if v, ok := in["paths"].([]interface{}); ok && len(v) > 0 {
-			at.Artifact.Paths, err = expandFiles(v)
-			if err != nil {
-				return nil, err
-			}
+			at.Artifact.Paths, _ = expandFiles(v)
 			artfct = spew.Sprintf("%+v", at.Artifact.Paths)
 			log.Println("ExpandArtifact  at.Artifact.Paths ", artfct)
 		}
@@ -123,10 +120,7 @@ func ExpandArtifact(artifactType string, ap []interface{}) (*commonpb.ArtifactSp
 		}
 
 		if v, ok := in["values_paths"].([]interface{}); ok && len(v) > 0 {
-			at.Artifact.ValuesPaths, err = expandFiles(v)
-			if err != nil {
-				return nil, err
-			}
+			at.Artifact.ValuesPaths, _ = expandFiles(v)
 			artfct = spew.Sprintf("%+v", at.Artifact.ValuesPaths)
 			log.Println("ExpandArtifact  at.Artifact.ValuesPaths ", artfct)
 		}
@@ -150,10 +144,7 @@ func ExpandArtifact(artifactType string, ap []interface{}) (*commonpb.ArtifactSp
 				}
 
 				if v, ok := inVref["values_paths"].([]interface{}); ok && len(v) > 0 {
-					at.Artifact.ValuesRef.ValuesPaths, err = expandFiles(v)
-					if err != nil {
-						return nil, err
-					}
+					at.Artifact.ValuesRef.ValuesPaths, _ = expandFiles(v)
 					artfct = spew.Sprintf("%+v", at.Artifact.ValuesRef.ValuesPaths)
 					log.Println("at.Artifact.ValuesRef.ValuesPaths ", artfct)
 				}


### PR DESCRIPTION
>1.Genentech using template files to generate values.yaml locally and using them as values path.
>2.values file generated in first run but once we delete generated values yaml ,it wont be able to generate again using the template file because we are erroring out the values path is not found
>3.This issue is not found in alermanager configuration because we are not erroring out even its empty so it was creating fine.
>4.Removed the error conditions to fix the issue