### PR TITLE
fix: ignore extra fields from eaas objects

### DIFF
--- a/rafay/resource_configcontext.go
+++ b/rafay/resource_configcontext.go
@@ -220,19 +220,19 @@ func expandConfigContextSpec(p []interface{}) (*eaaspb.ConfigContextSpec, error)
 
 	in := p[0].(map[string]interface{})
 
-	if v, ok := in["envs"].([]interface{}); ok {
+	if v, ok := in["envs"].([]interface{}); ok && len(v) > 0 {
 		spec.Envs = expandEnvVariables(v)
 	}
 
-	if v, ok := in["files"].([]interface{}); ok {
+	if v, ok := in["files"].([]interface{}); ok && len(v) > 0 {
 		spec.Files = expandCommonpbFiles(v)
 	}
 
-	if v, ok := in["variables"].([]interface{}); ok {
+	if v, ok := in["variables"].([]interface{}); ok && len(v) > 0 {
 		spec.Variables = expandVariables(v)
 	}
 
-	if v, ok := in["sharing"].([]interface{}); ok {
+	if v, ok := in["sharing"].([]interface{}); ok && len(v) > 0 {
 		spec.Sharing = expandSharingSpec(v)
 	}
 

--- a/rafay/resource_environment.go
+++ b/rafay/resource_environment.go
@@ -238,18 +238,18 @@ func expandEnvironmentSpec(p []interface{}) (*eaaspb.EnvironmentSpec, error) {
 	in := p[0].(map[string]interface{})
 
 	var err error
-	if v, ok := in["template"].([]interface{}); ok {
+	if v, ok := in["template"].([]interface{}); ok && len(v) > 0 {
 		spec.Template, err = expandTemplate(v)
 		if err != nil {
 			return spec, err
 		}
 	}
 
-	if v, ok := in["variables"].([]interface{}); ok {
+	if v, ok := in["variables"].([]interface{}); ok && len(v) > 0 {
 		spec.Variables = expandVariables(v)
 	}
 
-	if v, ok := in["sharing"].([]interface{}); ok {
+	if v, ok := in["sharing"].([]interface{}); ok && len(v) > 0 {
 		spec.Sharing = expandSharingSpec(v)
 	}
 

--- a/rafay/resource_environmenttemplate.go
+++ b/rafay/resource_environmenttemplate.go
@@ -232,23 +232,23 @@ func expandEnvironmentTemplateSpec(p []interface{}) (*eaaspb.EnvironmentTemplate
 		}
 	}
 
-	if v, ok := in["variables"].([]interface{}); ok {
+	if v, ok := in["variables"].([]interface{}); ok && len(v) > 0 {
 		spec.Variables = expandVariables(v)
 	}
 
-	if h, ok := in["hooks"].([]interface{}); ok {
+	if h, ok := in["hooks"].([]interface{}); ok && len(h) > 0 {
 		spec.Hooks = expandEnvironmentHooks(h)
 	}
 
-	if ag, ok := in["agents"].([]interface{}); ok {
+	if ag, ok := in["agents"].([]interface{}); ok && len(ag) > 0 {
 		spec.Agents = expandEaasAgents(ag)
 	}
 
-	if v, ok := in["sharing"].([]interface{}); ok {
+	if v, ok := in["sharing"].([]interface{}); ok && len(v) > 0 {
 		spec.Sharing = expandSharingSpec(v)
 	}
 
-	if v, ok := in["contexts"].([]interface{}); ok {
+	if v, ok := in["contexts"].([]interface{}); ok && len(v) > 0 {
 		spec.Contexts = expandContexts(v)
 	}
 
@@ -279,11 +279,11 @@ func expandEnvironmentResources(p []interface{}) ([]*eaaspb.EnvironmentResource,
 			obj.Name = v
 		}
 
-		if v, ok := in["resource_options"].([]interface{}); ok {
+		if v, ok := in["resource_options"].([]interface{}); ok && len(v) > 0 {
 			obj.ResourceOptions = expandResourceOptions(v)
 		}
 
-		if v, ok := in["depends_on"].([]interface{}); ok {
+		if v, ok := in["depends_on"].([]interface{}); ok && len(v) > 0 {
 			obj.DependsOn = expandDependsOn(v)
 		}
 
@@ -349,19 +349,19 @@ func expandEnvironmentHooks(p []interface{}) *eaaspb.EnvironmentHooks {
 
 	in := p[0].(map[string]interface{})
 
-	if h, ok := in["on_completion"].([]interface{}); ok {
+	if h, ok := in["on_completion"].([]interface{}); ok && len(h) > 0 {
 		hooks.OnCompletion = expandEaasHooks(h)
 	}
 
-	if h, ok := in["on_success"].([]interface{}); ok {
+	if h, ok := in["on_success"].([]interface{}); ok && len(h) > 0 {
 		hooks.OnSuccess = expandEaasHooks(h)
 	}
 
-	if h, ok := in["on_failure"].([]interface{}); ok {
+	if h, ok := in["on_failure"].([]interface{}); ok && len(h) > 0 {
 		hooks.OnFailure = expandEaasHooks(h)
 	}
 
-	if h, ok := in["on_init"].([]interface{}); ok {
+	if h, ok := in["on_init"].([]interface{}); ok && len(h) > 0 {
 		hooks.OnInit = expandEaasHooks(h)
 	}
 

--- a/rafay/resource_resourcetemplate.go
+++ b/rafay/resource_resourcetemplate.go
@@ -266,19 +266,19 @@ func expandProviderOptions(p []interface{}) *eaaspb.ResourceTemplateProviderOpti
 	}
 	in := p[0].(map[string]interface{})
 
-	if tp, ok := in["terraform"].([]interface{}); ok {
+	if tp, ok := in["terraform"].([]interface{}); ok && len(tp) > 0 {
 		po.Terraform = expandTerraformProviderOptions(tp)
 	}
 
-	if s, ok := in["system"].([]interface{}); ok {
+	if s, ok := in["system"].([]interface{}); ok && len(s) > 0 {
 		po.System = expandSystemProviderOptions(s)
 	}
 
-	if t, ok := in["terragrunt"].([]interface{}); ok {
+	if t, ok := in["terragrunt"].([]interface{}); ok && len(t) > 0 {
 		po.Terragrunt = expandTerragruntProviderOptions(t)
 	}
 
-	if p, ok := in["pulumi"].([]interface{}); ok {
+	if p, ok := in["pulumi"].([]interface{}); ok && len(p) > 0 {
 		po.Pulumi = expandPulumiProviderOptions(p)
 	}
 
@@ -338,23 +338,23 @@ func expandResourceHooks(p []interface{}) *eaaspb.ResourceHooks {
 
 	in := p[0].(map[string]interface{})
 
-	if h, ok := in["on_completion"].([]interface{}); ok {
+	if h, ok := in["on_completion"].([]interface{}); ok && len(h) > 0 {
 		hooks.OnCompletion = expandEaasHooks(h)
 	}
 
-	if h, ok := in["on_success"].([]interface{}); ok {
+	if h, ok := in["on_success"].([]interface{}); ok && len(h) > 0 {
 		hooks.OnSuccess = expandEaasHooks(h)
 	}
 
-	if h, ok := in["on_failure"].([]interface{}); ok {
+	if h, ok := in["on_failure"].([]interface{}); ok && len(h) > 0 {
 		hooks.OnFailure = expandEaasHooks(h)
 	}
 
-	if h, ok := in["on_init"].([]interface{}); ok {
+	if h, ok := in["on_init"].([]interface{}); ok && len(h) > 0 {
 		hooks.OnInit = expandEaasHooks(h)
 	}
 
-	if h, ok := in["provider"].([]interface{}); ok {
+	if h, ok := in["provider"].([]interface{}); ok && len(h) > 0 {
 		hooks.Provider = expandProviderHooks(h)
 	}
 
@@ -399,7 +399,7 @@ func expandTerraformProviderOptions(p []interface{}) *eaaspb.TerraformProviderOp
 		tpo.Version = h
 	}
 
-	if h, ok := in["use_system_state_store"].([]interface{}); ok {
+	if h, ok := in["use_system_state_store"].([]interface{}); ok && len(h) > 0 {
 		tpo.UseSystemStateStore = expandBoolValue(h)
 	}
 
@@ -411,11 +411,11 @@ func expandTerraformProviderOptions(p []interface{}) *eaaspb.TerraformProviderOp
 		tpo.BackendConfigs = toArrayString(bcfgs)
 	}
 
-	if h, ok := in["refresh"].([]interface{}); ok {
+	if h, ok := in["refresh"].([]interface{}); ok && len(h) > 0 {
 		tpo.Refresh = expandBoolValue(h)
 	}
 
-	if h, ok := in["lock"].([]interface{}); ok {
+	if h, ok := in["lock"].([]interface{}); ok && len(h) > 0 {
 		tpo.Lock = expandBoolValue(h)
 	}
 
@@ -470,11 +470,11 @@ func expandProviderHooks(p []interface{}) *eaaspb.ResourceTemplateProviderHooks 
 
 	in := p[0].(map[string]interface{})
 
-	if h, ok := in["terraform"].([]interface{}); ok {
+	if h, ok := in["terraform"].([]interface{}); ok && len(h) > 0 {
 		rtph.Terraform = expandTerraformProviderHooks(h)
 	}
 
-	if h, ok := in["pulumi"].([]interface{}); ok {
+	if h, ok := in["pulumi"].([]interface{}); ok && len(h) > 0 {
 		rtph.Pulumi = expandPulumiProviderHooks(h)
 	}
 
@@ -490,11 +490,11 @@ func expandTerraformProviderHooks(p []interface{}) *eaaspb.TerraformProviderHook
 
 	in := p[0].(map[string]interface{})
 
-	if h, ok := in["deploy"].([]interface{}); ok {
+	if h, ok := in["deploy"].([]interface{}); ok && len(h) > 0 {
 		tph.Deploy = expandTerraformDeployHooks(h)
 	}
 
-	if h, ok := in["destroy"].([]interface{}); ok {
+	if h, ok := in["destroy"].([]interface{}); ok && len(h) > 0 {
 		tph.Destroy = expandTerraformDestroyHooks(h)
 	}
 
@@ -528,19 +528,19 @@ func expandTerraformDeployHooks(p []interface{}) *eaaspb.TerraformDeployHooks {
 
 	in := p[0].(map[string]interface{})
 
-	if h, ok := in["init"].([]interface{}); ok {
+	if h, ok := in["init"].([]interface{}); ok && len(h) > 0 {
 		tdh.Init = expandLifecycleEventHooks(h)
 	}
 
-	if h, ok := in["plan"].([]interface{}); ok {
+	if h, ok := in["plan"].([]interface{}); ok && len(h) > 0 {
 		tdh.Plan = expandLifecycleEventHooks(h)
 	}
 
-	if h, ok := in["apply"].([]interface{}); ok {
+	if h, ok := in["apply"].([]interface{}); ok && len(h) > 0 {
 		tdh.Apply = expandLifecycleEventHooks(h)
 	}
 
-	if h, ok := in["output"].([]interface{}); ok {
+	if h, ok := in["output"].([]interface{}); ok && len(h) > 0 {
 		tdh.Output = expandLifecycleEventHooks(h)
 	}
 
@@ -555,15 +555,15 @@ func expandTerraformDestroyHooks(p []interface{}) *eaaspb.TerraformDestroyHooks 
 
 	in := p[0].(map[string]interface{})
 
-	if h, ok := in["init"].([]interface{}); ok {
+	if h, ok := in["init"].([]interface{}); ok && len(h) > 0 {
 		tdh.Init = expandLifecycleEventHooks(h)
 	}
 
-	if h, ok := in["plan"].([]interface{}); ok {
+	if h, ok := in["plan"].([]interface{}); ok && len(h) > 0 {
 		tdh.Plan = expandLifecycleEventHooks(h)
 	}
 
-	if h, ok := in["destroy"].([]interface{}); ok {
+	if h, ok := in["destroy"].([]interface{}); ok && len(h) > 0 {
 		tdh.Destroy = expandLifecycleEventHooks(h)
 	}
 
@@ -578,19 +578,19 @@ func expandPulumiDeployHooks(p []interface{}) *eaaspb.PulumiDeployHooks {
 
 	in := p[0].(map[string]interface{})
 
-	if h, ok := in["login"].([]interface{}); ok {
+	if h, ok := in["login"].([]interface{}); ok && len(h) > 0 {
 		pdh.Login = expandLifecycleEventHooks(h)
 	}
 
-	if h, ok := in["preview"].([]interface{}); ok {
+	if h, ok := in["preview"].([]interface{}); ok && len(h) > 0 {
 		pdh.Preview = expandLifecycleEventHooks(h)
 	}
 
-	if h, ok := in["up"].([]interface{}); ok {
+	if h, ok := in["up"].([]interface{}); ok && len(h) > 0 {
 		pdh.Up = expandLifecycleEventHooks(h)
 	}
 
-	if h, ok := in["output"].([]interface{}); ok {
+	if h, ok := in["output"].([]interface{}); ok && len(h) > 0 {
 		pdh.Output = expandLifecycleEventHooks(h)
 	}
 
@@ -605,15 +605,15 @@ func expandPulumiDestroyHooks(p []interface{}) *eaaspb.PulumiDestroyHooks {
 
 	in := p[0].(map[string]interface{})
 
-	if h, ok := in["login"].([]interface{}); ok {
+	if h, ok := in["login"].([]interface{}); ok && len(h) > 0 {
 		pdh.Login = expandLifecycleEventHooks(h)
 	}
 
-	if h, ok := in["preview"].([]interface{}); ok {
+	if h, ok := in["preview"].([]interface{}); ok && len(h) > 0 {
 		pdh.Preview = expandLifecycleEventHooks(h)
 	}
 
-	if h, ok := in["destroy"].([]interface{}); ok {
+	if h, ok := in["destroy"].([]interface{}); ok && len(h) > 0 {
 		pdh.Destroy = expandLifecycleEventHooks(h)
 	}
 
@@ -628,11 +628,11 @@ func expandLifecycleEventHooks(p []interface{}) *eaaspb.LifecycleEventHooks {
 
 	in := p[0].(map[string]interface{})
 
-	if h, ok := in["before"].([]interface{}); ok {
+	if h, ok := in["before"].([]interface{}); ok && len(h) > 0 {
 		lh.Before = expandEaasHooks(h)
 	}
 
-	if h, ok := in["after"].([]interface{}); ok {
+	if h, ok := in["after"].([]interface{}); ok && len(h) > 0 {
 		lh.After = expandEaasHooks(h)
 	}
 

--- a/rafay/resource_static_resource.go
+++ b/rafay/resource_static_resource.go
@@ -220,11 +220,11 @@ func expandResourceSpec(p []interface{}) (*eaaspb.ResourceSpec, error) {
 
 	in := p[0].(map[string]interface{})
 
-	if v, ok := in["variables"].([]interface{}); ok {
+	if v, ok := in["variables"].([]interface{}); ok && len(v) > 0 {
 		spec.Variables = expandVariables(v)
 	}
 
-	if v, ok := in["sharing"].([]interface{}); ok {
+	if v, ok := in["sharing"].([]interface{}); ok && len(v) > 0 {
 		spec.Sharing = expandSharingSpec(v)
 	}
 

--- a/rafay/utils.go
+++ b/rafay/utils.go
@@ -1340,7 +1340,7 @@ func expandVariables(p []interface{}) []*eaaspb.Variable {
 			obj.Value = v
 		}
 
-		if v, ok := in["options"].([]interface{}); ok {
+		if v, ok := in["options"].([]interface{}); ok && len(v) > 0 {
 			obj.Options = expandVariableOptions(v)
 		}
 
@@ -1370,7 +1370,7 @@ func expandVariableOptions(p []interface{}) *eaaspb.VariableOptions {
 		options.Required = v
 	}
 
-	if v, ok := opts["override"].([]interface{}); ok {
+	if v, ok := opts["override"].([]interface{}); ok && len(v) > 0 {
 		options.Override = expandVariableOverrideOptions(v)
 	}
 
@@ -1527,23 +1527,23 @@ func expandHookOptions(p []interface{}) *eaaspb.HookOptions {
 
 	in := p[0].(map[string]interface{})
 
-	if ao, ok := in["approval"].([]interface{}); ok {
+	if ao, ok := in["approval"].([]interface{}); ok && len(ao) > 0 {
 		ho.Approval = expandApprovalOptions(ao)
 	}
 
-	if no, ok := in["notification"].([]interface{}); ok {
+	if no, ok := in["notification"].([]interface{}); ok && len(no) > 0 {
 		ho.Notification = expandNotificationOptions(no)
 	}
 
-	if so, ok := in["script"].([]interface{}); ok {
+	if so, ok := in["script"].([]interface{}); ok && len(so) > 0 {
 		ho.Script = expandScriptOptions(so)
 	}
 
-	if co, ok := in["container"].([]interface{}); ok {
+	if co, ok := in["container"].([]interface{}); ok && len(co) > 0 {
 		ho.Container = expandContainerOptions(co)
 	}
 
-	if o, ok := in["http"].([]interface{}); ok {
+	if o, ok := in["http"].([]interface{}); ok && len(o) > 0 {
 		ho.Http = expandHttpOptions(o)
 	}
 
@@ -1562,19 +1562,19 @@ func expandApprovalOptions(p []interface{}) *eaaspb.ApprovalOptions {
 		ao.Type = t
 	}
 
-	if iao, ok := in["internal"].([]interface{}); ok {
+	if iao, ok := in["internal"].([]interface{}); ok && len(iao) > 0 {
 		ao.Internal = expandInternalApprovalOptions(iao)
 	}
 
-	if eao, ok := in["email"].([]interface{}); ok {
+	if eao, ok := in["email"].([]interface{}); ok && len(eao) > 0 {
 		ao.Email = expandEmailApprovalOptions(eao)
 	}
 
-	if jao, ok := in["jira"].([]interface{}); ok {
+	if jao, ok := in["jira"].([]interface{}); ok && len(jao) > 0 {
 		ao.Jira = expandJiraApprovalOptions(jao)
 	}
 
-	if ghao, ok := in["github_pull_request"].([]interface{}); ok {
+	if ghao, ok := in["github_pull_request"].([]interface{}); ok && len(ghao) > 0 {
 		ao.GithubPullRequest = expandGithubPRApprovalOptions(ghao)
 	}
 


### PR DESCRIPTION
Fixes:

[Redundant approval field is getting shown in version info for http hook options in resource template created using Terraform.](https://rafaysystems.atlassian.net/browse/RC-29497)
[Other providers with null values are showing up in version info of resource template created using Terraform.](https://rafaysystems.atlassian.net/browse/RC-29472)