### PR TITLE
fix for tf reapply / refresh / destroy of drivers

### DIFF
--- a/examples/resources/rafay_resource_template/resource.tf
+++ b/examples/resources/rafay_resource_template/resource.tf
@@ -9,9 +9,7 @@ resource "rafay_resource_template" "aws-elasticache" {
     provider_options {
       terraform {
         version = "v1.4.4"
-        use_system_state_store {
-          value = true
-        }
+        backend_type = "custom"
         backend_configs = ["path"]
         var_files       = ["path"]
         plugin_dirs     = ["path"]

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 toolchain go1.21.2
 
 require (
-	github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20231120174847-4e54f68e6bda
+	github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20231123075758-cd01db6be831
 	github.com/RafaySystems/rctl v1.29.1-0.20231107103246-992b949c4436
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-yaml/yaml v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/RafaySystems/eaas-playground v0.0.0-20231120064045-32c7f71c9eff h1:UK8IWW0tq4kiXaHK0ViWcLt+h6PXgbhVuKH0BJZPL6s=
 github.com/RafaySystems/eaas-playground v0.0.0-20231120064045-32c7f71c9eff/go.mod h1:xTxDW1ZBxyrRwPnm2KNRjPgxUwC4j8KN8htB7YfhRGg=
-github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20231120174847-4e54f68e6bda h1:4ueqH+frd/Wb5znTufPspNVHqncUeZRN/r/LBXlQzyE=
-github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20231120174847-4e54f68e6bda/go.mod h1:5OUUIO1vAvYK+td0G6d+QElBv6hwX2UE+M2+Ru1RIQM=
+github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20231123075758-cd01db6be831 h1:o6EY4t7G+Xuy2QWqpRjvfitf0gTjzSNPLjHhvmZ5DYs=
+github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20231123075758-cd01db6be831/go.mod h1:5OUUIO1vAvYK+td0G6d+QElBv6hwX2UE+M2+Ru1RIQM=
 github.com/RafaySystems/rctl v1.29.1-0.20231107103246-992b949c4436 h1:3FGcXvBs8/gB/KjURTZGM1iAeCE5/uKOeNmVP2eqGQQ=
 github.com/RafaySystems/rctl v1.29.1-0.20231107103246-992b949c4436/go.mod h1:u4adJb0+yvc+swmdF6WSNeqmAMqW3gx+DKWacVPjLFo=
 github.com/RoaringBitmap/roaring v1.6.0 h1:dc7kRiroETgJcHhWX6BerXkZz2b3JgLGg9nTURJL/og=

--- a/rafay/resource_resourcetemplate.go
+++ b/rafay/resource_resourcetemplate.go
@@ -1245,12 +1245,13 @@ func flattenEaasAgents(input []*commonpb.ResourceNameAndVersionRef) []interface{
 	return out
 }
 
-func flattenDriverResourceRef(input *commonpb.ResourceNameAndVersionRef) interface{} {
+func flattenDriverResourceRef(input *commonpb.ResourceNameAndVersionRef) []interface{} {
 	log.Println("flatten provider options driver start")
 	if input == nil {
 		return nil
 	}
 
+	out := make([]interface{}, 1)
 	obj := map[string]interface{}{}
 
 	if len(input.Name) > 0 {
@@ -1260,8 +1261,8 @@ func flattenDriverResourceRef(input *commonpb.ResourceNameAndVersionRef) interfa
 	if len(input.Version) > 0 {
 		obj["version"] = input.Version
 	}
-
-	return obj
+	out[0] = &obj
+	return out
 }
 
 func resourceResourceTemplateImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {

--- a/rafay/resource_resourcetemplate.go
+++ b/rafay/resource_resourcetemplate.go
@@ -433,6 +433,10 @@ func expandTerraformProviderOptions(p []interface{}) *eaaspb.TerraformProviderOp
 		tpo.BackendConfigs = toArrayString(bcfgs)
 	}
 
+	if bt, ok := in["backend_type"].(string); ok {
+		tpo.BackendType = bt
+	}
+
 	if h, ok := in["refresh"].([]interface{}); ok && len(h) > 0 {
 		tpo.Refresh = expandBoolValue(h)
 	}
@@ -771,6 +775,7 @@ func flattenTerraformProviderOptions(in *eaaspb.TerraformProviderOptions) []inte
 	obj["use_system_state_store"] = flattenBoolValue(in.UseSystemStateStore)
 	obj["var_files"] = toArrayInterface(in.VarFiles)
 	obj["backend_configs"] = toArrayInterface(in.BackendConfigs)
+	obj["backend_type"] = in.BackendType
 	obj["refresh"] = flattenBoolValue(in.Refresh)
 	obj["lock"] = flattenBoolValue(in.Lock)
 	obj["lock_timeout_seconds"] = in.LockTimeoutSeconds

--- a/rafay/utils.go
+++ b/rafay/utils.go
@@ -156,8 +156,9 @@ func toMapByte(in map[string]interface{}) map[string][]byte {
 			out[i] = []byte{}
 			continue
 		}
-		value := v.(string)
-		out[i] = []byte(value)
+		if vstr, ok := v.(string); ok {
+			out[i] = []byte(vstr)
+		}
 	}
 	return out
 }
@@ -169,8 +170,7 @@ func toMapByteInterface(in map[string][]byte) map[string]interface{} {
 			out[i] = []byte{}
 			continue
 		}
-		value := bytes.NewBuffer(v).String()
-		out[i] = []byte(value)
+		out[i] = bytes.NewBuffer(v).String()
 	}
 	return out
 }


### PR DESCRIPTION
Fixes

[Trying to reapply/refresh/destroy resource templates with custom driver using Terraform is giving error spec.0.provider_options.0.driver: '': source data must be an array or slice, got map](https://rafaysystems.atlassian.net/browse/RC-31453)

[Re-applying/Refreshing the value of files for container type driver using Terraform is giving 'spec.0.config.0.container.0.files.test.json: '' expected type 'string', got unconvertible type '[]uint8', value.[decimal equivalent value of file value]'](https://rafaysystems.atlassian.net/browse/RC-31324)

[Terraform support : backend changes : state store, TFC and custom](https://rafaysystems.atlassian.net/browse/RC-31382)