### PR TITLE
fix for tf reapply / refresh of drivers

### DIFF
--- a/rafay/resource_resourcetemplate.go
+++ b/rafay/resource_resourcetemplate.go
@@ -1257,12 +1257,13 @@ func flattenEaasAgents(input []*commonpb.ResourceNameAndVersionRef) []interface{
 	return out
 }
 
-func flattenDriverResourceRef(input *commonpb.ResourceNameAndVersionRef) interface{} {
+func flattenDriverResourceRef(input *commonpb.ResourceNameAndVersionRef) []interface{} {
 	log.Println("flatten provider options driver start")
 	if input == nil {
 		return nil
 	}
 
+	out := make([]interface{}, 1)
 	obj := map[string]interface{}{}
 
 	if len(input.Name) > 0 {
@@ -1273,7 +1274,8 @@ func flattenDriverResourceRef(input *commonpb.ResourceNameAndVersionRef) interfa
 		obj["version"] = input.Version
 	}
 
-	return obj
+	out[0] = &obj
+	return out
 }
 
 func expandTerraformProviderVolumeOptions(p []interface{}) []*eaaspb.TerraformProviderVolumeOptions {

--- a/rafay/utils.go
+++ b/rafay/utils.go
@@ -156,8 +156,9 @@ func toMapByte(in map[string]interface{}) map[string][]byte {
 			out[i] = []byte{}
 			continue
 		}
-		value := v.(string)
-		out[i] = []byte(value)
+		if vstr, ok := v.(string); ok {
+			out[i] = []byte(vstr)
+		}
 	}
 	return out
 }
@@ -169,8 +170,7 @@ func toMapByteInterface(in map[string][]byte) map[string]interface{} {
 			out[i] = []byte{}
 			continue
 		}
-		value := bytes.NewBuffer(v).String()
-		out[i] = []byte(value)
+		out[i] = bytes.NewBuffer(v).String()
 	}
 	return out
 }


### PR DESCRIPTION
Fix for 

[Re-applying/Refreshing the value of files for container type driver using Terraform is giving 'spec.0.config.0.container.0.files.test.json: '' expected type 'string', got unconvertible type '[]uint8', value.[decimal equivalent value of file value]'](https://rafaysystems.atlassian.net/browse/RC-31324)

[Trying to reapply/refresh/destroy resource templates with custom driver using Terraform is giving error spec.0.provider_options.0.driver: '': source data must be an array or slice, got map](https://rafaysystems.atlassian.net/browse/RC-31453)