### PR TITLE
fix for refresh rt / et with no active versions and added version state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 toolchain go1.21.2
 
 require (
-	github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20231206114447-c5e7dd8fd115
+	github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20231219102759-a36bb35083c5
 	github.com/RafaySystems/rctl v1.29.1-0.20231204052330-9f3b43966128
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-yaml/yaml v2.1.0+incompatible
@@ -71,7 +71,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371 // indirect
-	github.com/RafaySystems/eaas-playground v0.0.0-20231129121942-0b7a5d8087ec // indirect
+	github.com/RafaySystems/eaas-playground v0.0.0-20231219090313-d6c4aa9e513d // indirect
 	github.com/RoaringBitmap/roaring v1.6.0 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -158,10 +158,10 @@ github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371 h1:kkhsdkhsCv
 github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/RafaySystems/eaas-playground v0.0.0-20231129121942-0b7a5d8087ec h1:TQmKoqgLb2X4bOYArALta/nQCkZYZjMfYIzhXidS4fM=
-github.com/RafaySystems/eaas-playground v0.0.0-20231129121942-0b7a5d8087ec/go.mod h1:yKBgW4Ix9B8IadwFDOAJc/lrVjjoOyfxSztktpbGNn4=
-github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20231206114447-c5e7dd8fd115 h1:rIbmCXKn3SjXtHab+dq/9+CXn3mcEslkxhOlJZjwQKQ=
-github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20231206114447-c5e7dd8fd115/go.mod h1:HXZCHmUIy86zVFpecg7XYfUC6lAjGKYsm4OX6qjnG9w=
+github.com/RafaySystems/eaas-playground v0.0.0-20231219090313-d6c4aa9e513d h1:iSb138GQdgozVO8/UlMSqm92yi1CeED+Yh8Pg0jax0c=
+github.com/RafaySystems/eaas-playground v0.0.0-20231219090313-d6c4aa9e513d/go.mod h1:yKBgW4Ix9B8IadwFDOAJc/lrVjjoOyfxSztktpbGNn4=
+github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20231219102759-a36bb35083c5 h1:sbtB6h1ORvS0tCOrHcFkF2YxeGePKC99a3zNBlu0gFQ=
+github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20231219102759-a36bb35083c5/go.mod h1:/E4HHm3SgZIuwHzh2qYcHYL1fP4NZfKG674VaeFDw7E=
 github.com/RafaySystems/rctl v1.29.1-0.20231204052330-9f3b43966128 h1:38oS3XV5fOquTPwRpm4A8Zn94PJVy4ZV4Lj0s2la2w8=
 github.com/RafaySystems/rctl v1.29.1-0.20231204052330-9f3b43966128/go.mod h1:HEbozBKJFxvFgNU08bkC2wKcWFvrIokk2u9aOdVi3j0=
 github.com/RoaringBitmap/roaring v1.6.0 h1:dc7kRiroETgJcHhWX6BerXkZz2b3JgLGg9nTURJL/og=

--- a/rafay/resource_environmenttemplate.go
+++ b/rafay/resource_environmenttemplate.go
@@ -223,6 +223,10 @@ func expandEnvironmentTemplateSpec(p []interface{}) (*eaaspb.EnvironmentTemplate
 		spec.Version = v
 	}
 
+	if vs, ok := in["version_state"].(string); ok && len(vs) > 0 {
+		spec.VersionState = vs
+	}
+
 	var err error
 	if p, ok := in["resources"].([]interface{}); ok && len(p) > 0 {
 		spec.Resources, err = expandEnvironmentResources(p)
@@ -403,7 +407,7 @@ func flattenEnvironmentTemplate(d *schema.ResourceData, in *eaaspb.EnvironmentTe
 
 func flattenEnvironmentTemplateSpec(in *eaaspb.EnvironmentTemplateSpec, p []interface{}) ([]interface{}, error) {
 	if in == nil {
-		return nil, fmt.Errorf("%s", "flatten environment template spec empty input")
+		return nil, nil
 	}
 
 	obj := map[string]interface{}{}
@@ -412,6 +416,7 @@ func flattenEnvironmentTemplateSpec(in *eaaspb.EnvironmentTemplateSpec, p []inte
 	}
 
 	obj["version"] = in.Version
+	obj["version_state"] = in.VersionState
 
 	if len(in.Resources) > 0 {
 		v, ok := obj["resources"].([]interface{})

--- a/rafay/resource_resourcetemplate.go
+++ b/rafay/resource_resourcetemplate.go
@@ -223,6 +223,10 @@ func expandResourceTemplateSpec(p []interface{}) (*eaaspb.ResourceTemplateSpec, 
 		spec.Version = v
 	}
 
+	if vs, ok := in["version_state"].(string); ok && len(vs) > 0 {
+		spec.VersionState = vs
+	}
+
 	if p, ok := in["provider"].(string); ok && len(p) > 0 {
 		spec.Provider = p
 	}
@@ -708,7 +712,7 @@ func flattenResourceTemplate(d *schema.ResourceData, in *eaaspb.ResourceTemplate
 
 func flattenResourceTemplateSpec(in *eaaspb.ResourceTemplateSpec, p []interface{}) ([]interface{}, error) {
 	if in == nil {
-		return nil, fmt.Errorf("%s", "flatten resource spec empty input")
+		return nil, nil
 	}
 
 	obj := map[string]interface{}{}
@@ -717,6 +721,7 @@ func flattenResourceTemplateSpec(in *eaaspb.ResourceTemplateSpec, p []interface{
 	}
 
 	obj["version"] = in.Version
+	obj["version_state"] = in.VersionState
 	obj["provider"] = in.Provider
 	obj["provider_options"] = flattenProviderOptions(in.ProviderOptions)
 	obj["repository_options"] = flattenRepositoryOptions(in.RepositoryOptions)

--- a/rafay/resource_resourcetemplate.go
+++ b/rafay/resource_resourcetemplate.go
@@ -231,31 +231,31 @@ func expandResourceTemplateSpec(p []interface{}) (*eaaspb.ResourceTemplateSpec, 
 		spec.Provider = p
 	}
 
-	if po, ok := in["provider_options"].([]interface{}); ok {
+	if po, ok := in["provider_options"].([]interface{}); ok && len(po) > 0 {
 		spec.ProviderOptions = expandProviderOptions(po)
 	}
 
-	if ro, ok := in["repository_options"].([]interface{}); ok {
+	if ro, ok := in["repository_options"].([]interface{}); ok && len(ro) > 0 {
 		spec.RepositoryOptions = expandResourceTemplateRepositoryOptions(ro)
 	}
 
-	if v, ok := in["contexts"].([]interface{}); ok {
+	if v, ok := in["contexts"].([]interface{}); ok && len(v) > 0 {
 		spec.Contexts = expandContexts(v)
 	}
 
-	if v, ok := in["variables"].([]interface{}); ok {
+	if v, ok := in["variables"].([]interface{}); ok && len(v) > 0 {
 		spec.Variables = expandVariables(v)
 	}
 
-	if h, ok := in["hooks"].([]interface{}); ok {
+	if h, ok := in["hooks"].([]interface{}); ok && len(h) > 0 {
 		spec.Hooks = expandResourceHooks(h)
 	}
 
-	if ag, ok := in["agents"].([]interface{}); ok {
+	if ag, ok := in["agents"].([]interface{}); ok && len(ag) > 0 {
 		spec.Agents = expandEaasAgents(ag)
 	}
 
-	if v, ok := in["sharing"].([]interface{}); ok {
+	if v, ok := in["sharing"].([]interface{}); ok && len(v) > 0 {
 		spec.Sharing = expandSharingSpec(v)
 	}
 


### PR DESCRIPTION
Fixes

[Trying to refresh/re-apply with refresh Terraform resources for resource templates and environment templates is giving 'Error: flatten resource spec empty input' ](https://rafaysystems.atlassian.net/browse/RC-31870)

[Re-applying Terraform resources for environment template without any changes is giving error saying its version already exists](https://rafaysystems.atlassian.net/browse/RC-31951)

Added version_state support