### PR TITLE
updated agent to tf for agent, repo and driver (#484)

### DIFF
--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -30,7 +30,6 @@ resource "rafay_environment" "eks-rds-env-example" {
       options {
         description = "this is the name of resource created"
         sensitive   = false
-        required    = true
       }
     }
   }

--- a/rafay/resource_agent.go
+++ b/rafay/resource_agent.go
@@ -15,7 +15,6 @@ import (
 	"github.com/RafaySystems/rctl/pkg/agent"
 	"github.com/RafaySystems/rctl/pkg/config"
 	"github.com/RafaySystems/rctl/pkg/user"
-	"github.com/RafaySystems/rctl/pkg/versioninfo"
 	"github.com/davecgh/go-spew/spew"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -81,7 +80,7 @@ func resourceAgentCreate(ctx context.Context, d *schema.ResourceData, m interfac
 		}
 
 		auth := config.GetConfig().GetAppAuthProfile()
-		client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, versioninfo.GetUserAgent(), options.WithInsecureSkipVerify(auth.SkipServerCertValid))
+		client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, TF_USER_AGENT, options.WithInsecureSkipVerify(auth.SkipServerCertValid))
 		if err != nil {
 			return diags
 		}
@@ -144,7 +143,7 @@ func resourceAgentUpsert(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	auth := config.GetConfig().GetAppAuthProfile()
-	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, versioninfo.GetUserAgent(), options.WithInsecureSkipVerify(auth.SkipServerCertValid))
+	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, TF_USER_AGENT, options.WithInsecureSkipVerify(auth.SkipServerCertValid))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -208,7 +207,7 @@ func resourceAgentRead(ctx context.Context, d *schema.ResourceData, m interface{
 	}
 
 	auth := config.GetConfig().GetAppAuthProfile()
-	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, versioninfo.GetUserAgent(), options.WithInsecureSkipVerify(auth.SkipServerCertValid))
+	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, TF_USER_AGENT, options.WithInsecureSkipVerify(auth.SkipServerCertValid))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -270,7 +269,7 @@ func resourceAgentDelete(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	auth := config.GetConfig().GetAppAuthProfile()
-	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, versioninfo.GetUserAgent(), options.WithInsecureSkipVerify(auth.SkipServerCertValid))
+	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, TF_USER_AGENT, options.WithInsecureSkipVerify(auth.SkipServerCertValid))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/rafay/resource_driver.go
+++ b/rafay/resource_driver.go
@@ -14,7 +14,6 @@ import (
 	"github.com/RafaySystems/rafay-common/proto/types/hub/commonpb"
 	"github.com/RafaySystems/rafay-common/proto/types/hub/eaaspb"
 	"github.com/RafaySystems/rctl/pkg/config"
-	"github.com/RafaySystems/rctl/pkg/versioninfo"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -53,7 +52,7 @@ func resourceDriverCreate(ctx context.Context, d *schema.ResourceData, m interfa
 			return diags
 		}
 		auth := config.GetConfig().GetAppAuthProfile()
-		client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, versioninfo.GetUserAgent(), options.WithInsecureSkipVerify(auth.SkipServerCertValid))
+		client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, TF_USER_AGENT, options.WithInsecureSkipVerify(auth.SkipServerCertValid))
 		if err != nil {
 			return diags
 		}
@@ -83,7 +82,7 @@ func resourceDriverUpsert(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 
 	auth := config.GetConfig().GetAppAuthProfile()
-	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, versioninfo.GetUserAgent(), options.WithInsecureSkipVerify(auth.SkipServerCertValid))
+	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, TF_USER_AGENT, options.WithInsecureSkipVerify(auth.SkipServerCertValid))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -114,7 +113,7 @@ func resourceDriverRead(ctx context.Context, d *schema.ResourceData, m interface
 	}
 
 	auth := config.GetConfig().GetAppAuthProfile()
-	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, versioninfo.GetUserAgent(), options.WithInsecureSkipVerify(auth.SkipServerCertValid))
+	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, TF_USER_AGENT, options.WithInsecureSkipVerify(auth.SkipServerCertValid))
 	if err != nil {
 		log.Println("read client err")
 		return diag.FromErr(err)
@@ -171,7 +170,7 @@ func resourceDriverDelete(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 
 	auth := config.GetConfig().GetAppAuthProfile()
-	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, versioninfo.GetUserAgent(), options.WithInsecureSkipVerify(auth.SkipServerCertValid))
+	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, TF_USER_AGENT, options.WithInsecureSkipVerify(auth.SkipServerCertValid))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/rafay/resource_environmenttemplate.go
+++ b/rafay/resource_environmenttemplate.go
@@ -227,6 +227,14 @@ func expandEnvironmentTemplateSpec(p []interface{}) (*eaaspb.EnvironmentTemplate
 		spec.VersionState = vs
 	}
 
+	if iconurl, ok := in["icon_url"].(string); ok && len(iconurl) > 0 {
+		spec.IconURL = iconurl
+	}
+
+	if readme, ok := in["readme"].(string); ok && len(readme) > 0 {
+		spec.Readme = readme
+	}
+
 	var err error
 	if p, ok := in["resources"].([]interface{}); ok && len(p) > 0 {
 		spec.Resources, err = expandEnvironmentResources(p)
@@ -417,6 +425,8 @@ func flattenEnvironmentTemplateSpec(in *eaaspb.EnvironmentTemplateSpec, p []inte
 
 	obj["version"] = in.Version
 	obj["version_state"] = in.VersionState
+	obj["icon_url"] = in.IconURL
+	obj["readme"] = in.Readme
 
 	if len(in.Resources) > 0 {
 		v, ok := obj["resources"].([]interface{})

--- a/rafay/resource_repositories.go
+++ b/rafay/resource_repositories.go
@@ -16,7 +16,6 @@ import (
 	"github.com/RafaySystems/rafay-common/proto/types/hub/integrationspb"
 	"github.com/RafaySystems/rctl/pkg/config"
 	"github.com/RafaySystems/rctl/pkg/user"
-	"github.com/RafaySystems/rctl/pkg/versioninfo"
 	"github.com/davecgh/go-spew/spew"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -109,7 +108,7 @@ func resourceRepositoryUpsert(ctx context.Context, d *schema.ResourceData, m int
 	}
 
 	auth := config.GetConfig().GetAppAuthProfile()
-	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, versioninfo.GetUserAgent(), options.WithInsecureSkipVerify(auth.SkipServerCertValid))
+	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, TF_USER_AGENT, options.WithInsecureSkipVerify(auth.SkipServerCertValid))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -172,7 +171,7 @@ func resourceRepositoriesRead(ctx context.Context, d *schema.ResourceData, m int
 	}
 
 	auth := config.GetConfig().GetAppAuthProfile()
-	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, versioninfo.GetUserAgent(), options.WithInsecureSkipVerify(auth.SkipServerCertValid))
+	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, TF_USER_AGENT, options.WithInsecureSkipVerify(auth.SkipServerCertValid))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -239,7 +238,7 @@ func resourceRepositoriesDelete(ctx context.Context, d *schema.ResourceData, m i
 	}
 
 	auth := config.GetConfig().GetAppAuthProfile()
-	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, versioninfo.GetUserAgent(), options.WithInsecureSkipVerify(auth.SkipServerCertValid))
+	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, TF_USER_AGENT, options.WithInsecureSkipVerify(auth.SkipServerCertValid))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/rafay/utils.go
+++ b/rafay/utils.go
@@ -2053,6 +2053,10 @@ func expandV3MetaData(p []interface{}) *commonpb.Metadata {
 	if v, ok := in["annotations"].(map[string]interface{}); ok && len(v) > 0 {
 		obj.Annotations = toMapString(v)
 	}
+
+	if v, ok := in["display_name"].(string); ok && len(v) > 0 {
+		obj.DisplayName = v
+	}
 	return obj
 }
 
@@ -2081,6 +2085,10 @@ func flattenV3MetaData(in *commonpb.Metadata) []interface{} {
 
 	if len(in.Annotations) > 0 {
 		obj["annotations"] = toMapInterface(in.Annotations)
+	}
+
+	if len(in.DisplayName) > 0 {
+		obj["display_name"] = in.DisplayName
 	}
 
 	return []interface{}{obj}


### PR DESCRIPTION
Fixes

[The agent in audit logs is shown as 'RCTL' for repository, gitops agent and driver created using Terraform](https://rafaysystems.atlassian.net/browse/RC-32466)
[Support new environment template fields in Terraform provider](https://rafaysystems.atlassian.net/browse/RC-32454)