### PR TITLE
Added a flag to identify data-read vs resource-read to safely implement

### DIFF
--- a/rafay/data_addon.go
+++ b/rafay/data_addon.go
@@ -73,7 +73,7 @@ func dataAddonRead(ctx context.Context, d *schema.ResourceData, m interface{}) d
 	addst := spew.Sprintf("%+v", addon)
 	log.Println("dataAddonRead addst", addst)
 
-	err = flattenAddon(d, addon)
+	err = flattenAddon(d, addon, true)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/rafay/resource_addon.go
+++ b/rafay/resource_addon.go
@@ -196,7 +196,7 @@ func resourceAddonRead(ctx context.Context, d *schema.ResourceData, m interface{
 	addst := spew.Sprintf("%+v", addon)
 	log.Println("resourceAddonRead addst", addst)
 
-	err = flattenAddon(d, addon)
+	err = flattenAddon(d, addon, false)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -272,7 +272,7 @@ func expandAddonSpec(p []interface{}) (*infrapb.AddonSpec, error) {
 
 // Flatteners
 
-func flattenAddon(d *schema.ResourceData, in *infrapb.Addon) error {
+func flattenAddon(d *schema.ResourceData, in *infrapb.Addon, dataResource bool) error {
 	if in == nil {
 		return nil
 	}
@@ -291,7 +291,7 @@ func flattenAddon(d *schema.ResourceData, in *infrapb.Addon) error {
 	// w1 := spew.Sprintf("%+v", v)
 	// log.Println("flattenAddon before ", w1)
 	var ret []interface{}
-	ret, err = flattenAddonSpec(in.Spec, v)
+	ret, err = flattenAddonSpec(dataResource, in.Spec, v)
 	if err != nil {
 		return err
 	}
@@ -306,7 +306,7 @@ func flattenAddon(d *schema.ResourceData, in *infrapb.Addon) error {
 	return nil
 }
 
-func flattenAddonSpec(in *infrapb.AddonSpec, p []interface{}) ([]interface{}, error) {
+func flattenAddonSpec(dataResource bool, in *infrapb.AddonSpec, p []interface{}) ([]interface{}, error) {
 	if in == nil {
 		return nil, fmt.Errorf("%s", "flattenAddonSpec empty input")
 	}
@@ -334,7 +334,7 @@ func flattenAddonSpec(in *infrapb.AddonSpec, p []interface{}) ([]interface{}, er
 
 	var ret []interface{}
 	var err error
-	ret, err = FlattenArtifactSpec(in.Artifact, v)
+	ret, err = FlattenArtifactSpec(dataResource, in.Artifact, v)
 	if err != nil {
 		log.Println("FlattenArtifactSpec error ", err)
 		return nil, err

--- a/rafay/resource_cluster_mesh_rule.go
+++ b/rafay/resource_cluster_mesh_rule.go
@@ -301,7 +301,7 @@ func flattenClusterMeshRuleSpec(in *servicemeshpb.ClusterMeshRuleSpec, p []inter
 
 	var ret []interface{}
 	var err error
-	ret, err = FlattenArtifactSpec(in.Artifact, v)
+	ret, err = FlattenArtifactSpec(false, in.Artifact, v)
 	if err != nil {
 		log.Println("FlattenArtifactSpec error ", err)
 		return nil, err

--- a/rafay/resource_cluster_network_policy_rule.go
+++ b/rafay/resource_cluster_network_policy_rule.go
@@ -301,7 +301,7 @@ func flattenClusterNetworkPolicyRuleSpec(in *securitypb.ClusterNetworkPolicyRule
 
 	var ret []interface{}
 	var err error
-	ret, err = FlattenArtifactSpec(in.Artifact, v)
+	ret, err = FlattenArtifactSpec(false, in.Artifact, v)
 	if err != nil {
 		log.Println("FlattenArtifactSpec error ", err)
 		return nil, err

--- a/rafay/resource_namespace_mesh_rule.go
+++ b/rafay/resource_namespace_mesh_rule.go
@@ -301,7 +301,7 @@ func flattenNamespaceMeshRuleSpec(in *servicemeshpb.NamespaceMeshRuleSpec, p []i
 
 	var ret []interface{}
 	var err error
-	ret, err = FlattenArtifactSpec(in.Artifact, v)
+	ret, err = FlattenArtifactSpec(false, in.Artifact, v)
 	if err != nil {
 		log.Println("FlattenArtifactSpec error ", err)
 		return nil, err

--- a/rafay/resource_namespace_network_policy_rule.go
+++ b/rafay/resource_namespace_network_policy_rule.go
@@ -301,7 +301,7 @@ func flattenNamespaceNetworkPolicyRuleSpec(in *securitypb.NamespaceNetworkPolicy
 
 	var ret []interface{}
 	var err error
-	ret, err = FlattenArtifactSpec(in.Artifact, v)
+	ret, err = FlattenArtifactSpec(false, in.Artifact, v)
 	if err != nil {
 		log.Println("FlattenArtifactSpec error ", err)
 		return nil, err

--- a/rafay/resource_opa_constraint.go
+++ b/rafay/resource_opa_constraint.go
@@ -310,7 +310,7 @@ func flattenOPAConstraintSpec(in *opapb.OPAConstraintSpec, p []interface{}) ([]i
 
 	var ret []interface{}
 	var err error
-	ret, err = FlattenArtifactSpec(in.Artifact, v)
+	ret, err = FlattenArtifactSpec(false, in.Artifact, v)
 	if err != nil {
 		log.Println("FlattenArtifactSpec error ", err)
 		return nil, err

--- a/rafay/resource_opa_constraint_template.go
+++ b/rafay/resource_opa_constraint_template.go
@@ -318,7 +318,7 @@ func flattenOPAConstraintTemplateSpec(in *opapb.OPAConstraintTemplateSpec, p []i
 
 	var ret []interface{}
 	var err error
-	ret, err = FlattenArtifactSpec(in.Artifact, v)
+	ret, err = FlattenArtifactSpec(false, in.Artifact, v)
 	if err != nil {
 		log.Println("FlattenArtifactSpec error ", err)
 		return nil, err

--- a/rafay/resource_secrets_provider.go
+++ b/rafay/resource_secrets_provider.go
@@ -302,7 +302,7 @@ func flattenSecretProviderSpec(in *integrationspb.SecretProviderClassSpec, p []i
 
 		var ret []interface{}
 		var err error
-		ret, err = FlattenArtifactSpec(in.Artifact, v)
+		ret, err = FlattenArtifactSpec(false, in.Artifact, v)
 		if err != nil {
 			log.Println("FlattenArtifactSpec error ", err)
 			return nil, err

--- a/rafay/resource_workload.go
+++ b/rafay/resource_workload.go
@@ -436,7 +436,7 @@ func flattenWorkloadSpec(in *appspb.WorkloadSpec, p []interface{}) ([]interface{
 
 	var ret []interface{}
 	var err error
-	ret, err = FlattenArtifactSpec(in.Artifact, v)
+	ret, err = FlattenArtifactSpec(false, in.Artifact, v)
 	if err != nil {
 		log.Println("FlattenArtifactSpec error ", err)
 		return nil, err

--- a/rafay/resource_workloadtemplate.go
+++ b/rafay/resource_workloadtemplate.go
@@ -391,7 +391,7 @@ func flattenWorkloadTemplateSpec(in *appspb.WorkloadTemplateSpec, p []interface{
 
 	var ret []interface{}
 	var err error
-	ret, err = FlattenArtifactSpec(in.Artifact, v)
+	ret, err = FlattenArtifactSpec(false, in.Artifact, v)
 	if err != nil {
 		log.Println("FlattenArtifactSpec error ", err)
 		return nil, err

--- a/rafay/resource_ztkarule.go
+++ b/rafay/resource_ztkarule.go
@@ -322,7 +322,7 @@ func flattenZTKARuleSpec(in *systempb.ZTKARuleSpec, p []interface{}) ([]interfac
 	}
 	var flattenArtifact []interface{}
 	var err error
-	flattenArtifact, err = FlattenArtifactSpec(in.Artifact, v)
+	flattenArtifact, err = FlattenArtifactSpec(false, in.Artifact, v)
 	if err != nil {
 		log.Println("FlattenArtifactSpec error ", err)
 		return nil, err

--- a/rafay/structure_artifact.go
+++ b/rafay/structure_artifact.go
@@ -406,7 +406,7 @@ func FlattenArtifactOptions(at *artifactTranspose, p []interface{}) ([]interface
 }
 
 // FlattenArtifactSpec ArtifactSpec to TF State
-func FlattenArtifactSpec(in *commonpb.ArtifactSpec, p []interface{}) ([]interface{}, error) {
+func FlattenArtifactSpec(dataResource bool, in *commonpb.ArtifactSpec, p []interface{}) ([]interface{}, error) {
 	if in == nil {
 		log.Println("FlattenArtifactSpec empty input")
 		return nil, fmt.Errorf("%s", "FlattenArtifactSpec empty input")
@@ -446,13 +446,19 @@ func FlattenArtifactSpec(in *commonpb.ArtifactSpec, p []interface{}) ([]interfac
 	if !ok {
 		v = []interface{}{}
 	}
-	FlattenArtifact(&at, v)
+	artfct, err := FlattenArtifact(&at, v)
+	if dataResource && err == nil {
+		obj["artifact"] = artfct
+	}
 
 	v, ok = obj["options"].([]interface{})
 	if !ok {
 		v = []interface{}{}
 	}
-	FlattenArtifactOptions(&at, v)
+	artfctOpts, err := FlattenArtifactOptions(&at, v)
+	if dataResource && err == nil {
+		obj["options"] = artfctOpts
+	}
 
 	// XXX Debug
 	// ob = spew.Sprintf("%+v", p)


### PR DESCRIPTION
fix that is backwrd compatabile since FlattenArtifactSpec is being used from mny places. Did not want to increase the regression risk.