### PR TITLE
Send User Agent for AKS and EKS cluster APIs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.22.3
 toolchain go1.22.4
 
 require (
-	github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20240621115302-afdaffa23f8e
-	github.com/RafaySystems/rctl v1.29.1-0.20240620091555-2554c07f1905
+	github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20240625104151-00363a6567c5
+	github.com/RafaySystems/rctl v1.29.1-0.20240702081833-6abbc0ca2144
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/goccy/go-yaml v1.9.5

--- a/go.sum
+++ b/go.sum
@@ -27,10 +27,10 @@ github.com/RafaySystems/eaas-playground v0.0.0-20240621113209-3a4368836b68 h1:iA
 github.com/RafaySystems/eaas-playground v0.0.0-20240621113209-3a4368836b68/go.mod h1:myv/SlyiD0eSrEstjp8/VSYKka5DSh3IJzFJXlBGxJY=
 github.com/RafaySystems/edge-common v1.24.1-0.20240313173939-2a7f4af9a0b1 h1:wP27Eemjf9ng0vZzU/nrVm/MhS2vucqNav8BYWL1dj4=
 github.com/RafaySystems/edge-common v1.24.1-0.20240313173939-2a7f4af9a0b1/go.mod h1:bIn92SQa3X+1/vSBF/b5cyw7/t7r66GBvIOqSl3eMEc=
-github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20240621115302-afdaffa23f8e h1:kMTtRIdHpnbUwd8BRwMipeiYlNHpHMsMV2AxtQzGCfQ=
-github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20240621115302-afdaffa23f8e/go.mod h1:N91SiPrmozLroAgjSw1lbMhR7dkDHqU1cDfZf6CRPFI=
-github.com/RafaySystems/rctl v1.29.1-0.20240620091555-2554c07f1905 h1:DCTb3E48S6mXSo43WWANWjhxvVA3xBnkRmVsd2mE7OE=
-github.com/RafaySystems/rctl v1.29.1-0.20240620091555-2554c07f1905/go.mod h1:pptEYrmz8khOwz9KDCpPJPNR6PEst6MsQY/RKZtvYno=
+github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20240625104151-00363a6567c5 h1:g06Ok3aaXr7UyEPxKUgC9O5A8rXmGrxv/W4eNRnVTio=
+github.com/RafaySystems/rafay-common v1.29.0-rc5.0.20240625104151-00363a6567c5/go.mod h1:N91SiPrmozLroAgjSw1lbMhR7dkDHqU1cDfZf6CRPFI=
+github.com/RafaySystems/rctl v1.29.1-0.20240702081833-6abbc0ca2144 h1:jCKjcJ8DSKTQGlQJiQM6gi7uWtLUQaT8hSaSrqNLwlk=
+github.com/RafaySystems/rctl v1.29.1-0.20240702081833-6abbc0ca2144/go.mod h1:Wh5/M9cEjMaxCtQG2k6A/FlnKwYWs/aAaOiLBjI2wwM=
 github.com/RoaringBitmap/roaring v1.9.4 h1:yhEIoH4YezLYT04s1nHehNO64EKFTop/wBhxv2QzDdQ=
 github.com/RoaringBitmap/roaring v1.9.4/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
 github.com/abhay-krishna/cluster-api v1.4.2-eksa.1 h1:mO+idOdh9Bpumgo41WJcrASPtJGSgmRxHNiwtUdUa+E=

--- a/rafay/cluster_util.go
+++ b/rafay/cluster_util.go
@@ -333,7 +333,7 @@ func getProjectIDFromName(projectName string) (string, error) {
 }
 
 func getClusterConditions(edgeId, projectId string) (bool, bool, error) {
-	cluster, err := cluster.GetClusterWithEdgeID(edgeId, projectId)
+	cluster, err := cluster.GetClusterWithEdgeID(edgeId, projectId, uaDef)
 	if err != nil {
 		log.Printf("error while getCluster %s", err.Error())
 		return false, false, err

--- a/rafay/const.go
+++ b/rafay/const.go
@@ -1,0 +1,5 @@
+package rafay
+
+// UserAgent for Terraform requests. It is currently used by v1
+// clusters (AKS and EKS) to identiy source of the request.
+const uaDef = "terraform"

--- a/rafay/data_aks_cluster.go
+++ b/rafay/data_aks_cluster.go
@@ -106,7 +106,7 @@ func dataAKSClusterRead(ctx context.Context, d *schema.ResourceData, m interface
 		return diags
 	}
 
-	c, err := cluster.GetCluster(obj.Metadata.Name, project.ID)
+	c, err := cluster.GetCluster(obj.Metadata.Name, project.ID, uaDef)
 	if err != nil {
 		log.Printf("error in get cluster %s", err.Error())
 		if strings.Contains(err.Error(), "not found") {
@@ -124,13 +124,13 @@ func dataAKSClusterRead(ctx context.Context, d *schema.ResourceData, m interface
 	// another
 	logger := glogger.GetLogger()
 	rctlCfg := config.GetConfig()
-	clusterSpecYaml, err := clusterctl.GetClusterSpec(logger, rctlCfg, c.Name, project.ID)
+	clusterSpecYaml, err := clusterctl.GetClusterSpec(logger, rctlCfg, c.Name, project.ID, uaDef)
 	if err != nil {
 		log.Printf("error in get clusterspec %s", err.Error())
 		return diag.FromErr(err)
 	}
 
-	cluster, err := cluster.GetCluster(c.Name, project.ID)
+	cluster, err := cluster.GetCluster(c.Name, project.ID, uaDef)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/rafay/data_eks_cluster.go
+++ b/rafay/data_eks_cluster.go
@@ -109,7 +109,7 @@ func dataEKSClusterRead(ctx context.Context, d *schema.ResourceData, m interface
 		log.Print("error converting project name to id")
 		return diag.Errorf("error converting project name to project ID")
 	}
-	c, err := cluster.GetCluster(clusterName, projectID)
+	c, err := cluster.GetCluster(clusterName, projectID, uaDef)
 	if err != nil {
 		log.Printf("error in get cluster %s", err.Error())
 		if strings.Contains(err.Error(), "not found") {
@@ -122,7 +122,7 @@ func dataEKSClusterRead(ctx context.Context, d *schema.ResourceData, m interface
 	log.Println("got cluster from backend")
 	logger := glogger.GetLogger()
 	rctlCfg := config.GetConfig()
-	clusterSpecYaml, err := clusterctl.GetClusterSpec(logger, rctlCfg, c.Name, projectID)
+	clusterSpecYaml, err := clusterctl.GetClusterSpec(logger, rctlCfg, c.Name, projectID, uaDef)
 	if err != nil {
 		log.Printf("error in get clusterspec %s", err.Error())
 		return diag.FromErr(err)

--- a/rafay/resource_aks_cluster_spec.go
+++ b/rafay/resource_aks_cluster_spec.go
@@ -90,7 +90,7 @@ func aksClusterSpecCTL(config *config.Config, rafayConfigs, clusterConfigs [][]b
 	// Make request
 	for clusterName, configBytes := range configMap {
 		/* only suppoort one cluster */
-		rsponse, err := clusterctl.Apply(logger, config, clusterName, configBytes, dryRun, false, false)
+		rsponse, err := clusterctl.Apply(logger, config, clusterName, configBytes, dryRun, false, false, uaDef)
 
 		if err != nil {
 			log.Println("error performing apply on cluster: ", clusterName, err)
@@ -190,7 +190,7 @@ func resourceAKSClusterSpecUpsert(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	time.Sleep(10 * time.Second)
-	s, errGet := cluster.GetCluster(d.Get("name").(string), project.ID)
+	s, errGet := cluster.GetCluster(d.Get("name").(string), project.ID, uaDef)
 	if errGet != nil {
 		log.Printf("error while getCluster %s", errGet.Error())
 		return diag.FromErr(errGet)
@@ -201,7 +201,7 @@ func resourceAKSClusterSpecUpsert(ctx context.Context, d *schema.ResourceData, m
 		log.Printf("Cluster Provision may take upto 15-20 Minutes")
 		for {
 			time.Sleep(60 * time.Second)
-			check, errGet := cluster.GetCluster(d.Get("name").(string), project.ID)
+			check, errGet := cluster.GetCluster(d.Get("name").(string), project.ID, uaDef)
 			if errGet != nil {
 				log.Printf("error while getCluster %s", errGet.Error())
 				return diag.FromErr(errGet)
@@ -255,7 +255,7 @@ func resourceAKSClusterSpecRead(ctx context.Context, d *schema.ResourceData, m i
 		fmt.Printf("project does not exist")
 		return diags
 	}
-	c, err := cluster.GetCluster(d.Get("name").(string), project.ID)
+	c, err := cluster.GetCluster(d.Get("name").(string), project.ID, uaDef)
 	if err != nil {
 		log.Printf("error in get cluster %s", err.Error())
 		if strings.Contains(err.Error(), "not found") {
@@ -270,7 +270,7 @@ func resourceAKSClusterSpecRead(ctx context.Context, d *schema.ResourceData, m i
 	if check {
 		logger := glogger.GetLogger()
 		rctlCfg := config.GetConfig()
-		clusterSpecYaml, err := clusterctl.GetClusterSpec(logger, rctlCfg, c.Name, project.ID)
+		clusterSpecYaml, err := clusterctl.GetClusterSpec(logger, rctlCfg, c.Name, project.ID, uaDef)
 		if err != nil {
 			log.Printf("error in get clusterspec %s", err.Error())
 			return diag.FromErr(err)
@@ -311,7 +311,7 @@ func resourceAKSClusterSpecUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(fmt.Errorf("project does not exist"))
 	}
 
-	_, err = cluster.GetCluster(d.Get("name").(string), project.ID)
+	_, err = cluster.GetCluster(d.Get("name").(string), project.ID, uaDef)
 	if err != nil {
 		log.Printf("error in get cluster %s", err.Error())
 		return diag.FromErr(err)
@@ -348,7 +348,7 @@ func resourceAKSClusterSpecDelete(ctx context.Context, d *schema.ResourceData, m
 		return diags
 	}
 
-	errDel := cluster.DeleteCluster(d.Get("name").(string), project.ID, false)
+	errDel := cluster.DeleteCluster(d.Get("name").(string), project.ID, false, uaDef)
 	if errDel != nil {
 		log.Printf("delete cluster error %s", errDel.Error())
 		return diag.FromErr(errDel)
@@ -357,7 +357,7 @@ func resourceAKSClusterSpecDelete(ctx context.Context, d *schema.ResourceData, m
 	if d.Get("waitflag").(string) == "1" {
 		for {
 			time.Sleep(60 * time.Second)
-			check, errGet := cluster.GetCluster(d.Get("name").(string), project.ID)
+			check, errGet := cluster.GetCluster(d.Get("name").(string), project.ID, uaDef)
 			if errGet != nil {
 				log.Printf("error while getCluster %s, delete success", errGet.Error())
 				break

--- a/rafay/resource_cluster_sharing.go
+++ b/rafay/resource_cluster_sharing.go
@@ -115,7 +115,7 @@ func resourceClusterSharingUpsert(ctx context.Context, d *schema.ResourceData, c
 		return diags
 	}
 
-	clusterObj, errGet := cluster.GetCluster(clusterName, projectObj.ID)
+	clusterObj, errGet := cluster.GetCluster(clusterName, projectObj.ID, uaDef)
 	if errGet != nil {
 		log.Printf("failed to get cluster info %s", errGet.Error())
 		return diag.FromErr(errGet)
@@ -318,7 +318,7 @@ func resourceClusterSharingRead(ctx context.Context, d *schema.ResourceData, m i
 		return diags
 	}
 
-	clusterObj, errGet := cluster.GetCluster(clusterName, projectObj.ID)
+	clusterObj, errGet := cluster.GetCluster(clusterName, projectObj.ID, uaDef)
 	if errGet != nil {
 		log.Printf("failed to get cluster info %s", errGet.Error())
 		return diag.FromErr(errGet)
@@ -463,7 +463,7 @@ func resourceClusterSharingDelete(ctx context.Context, d *schema.ResourceData, m
 		return diags
 	}
 
-	clusterObj, errGet := cluster.GetCluster(clusterName, projectObj.ID)
+	clusterObj, errGet := cluster.GetCluster(clusterName, projectObj.ID, uaDef)
 	if errGet != nil {
 		log.Printf("failed to get cluster info %s", errGet.Error())
 		return diag.FromErr(errGet)

--- a/rafay/resource_eks_cluster.go
+++ b/rafay/resource_eks_cluster.go
@@ -2321,7 +2321,7 @@ func processEKSFilebytes(ctx context.Context, d *schema.ResourceData, m interfac
 	rctlConfig := config.GetConfig()
 
 	log.Printf("calling cluster ctl:\n%s", b.String())
-	response, err := clusterctl.Apply(logger, rctlConfig, clusterName, b.Bytes(), false, false, false)
+	response, err := clusterctl.Apply(logger, rctlConfig, clusterName, b.Bytes(), false, false, false, uaDef)
 	if err != nil {
 		log.Printf("cluster error 1: %s", err)
 		return diag.FromErr(err)
@@ -2338,7 +2338,7 @@ func processEKSFilebytes(ctx context.Context, d *schema.ResourceData, m interfac
 		return nil
 	}
 	time.Sleep(10 * time.Second)
-	s, errGet := cluster.GetCluster(clusterName, projectID)
+	s, errGet := cluster.GetCluster(clusterName, projectID, uaDef)
 	if errGet != nil {
 		log.Printf("error while getCluster %s", errGet.Error())
 		return diag.FromErr(errGet)
@@ -2358,13 +2358,13 @@ LOOP:
 			return diag.Errorf("cluster operation stopped for cluster: `%s` due to operation timeout", clusterName)
 		case <-ticker.C:
 			log.Printf("Cluster operation not completed for edgename: %s and projectname: %s. Waiting 60 seconds more for cluster to complete the operation.", clusterName, projectName)
-			check, errGet := cluster.GetCluster(yamlClusterMetadata.Metadata.Name, projectID)
+			check, errGet := cluster.GetCluster(yamlClusterMetadata.Metadata.Name, projectID, uaDef)
 			if errGet != nil {
 				log.Printf("error while getCluster %s", errGet.Error())
 				return diag.FromErr(errGet)
 			}
 			edgeId := check.ID
-			check, errGet = cluster.GetClusterWithEdgeID(edgeId, projectID)
+			check, errGet = cluster.GetClusterWithEdgeID(edgeId, projectID, uaDef)
 			if errGet != nil {
 				log.Printf("error while getCluster %s", errGet.Error())
 				return diag.FromErr(errGet)
@@ -6069,7 +6069,7 @@ func resourceEKSClusterRead(ctx context.Context, d *schema.ResourceData, m inter
 		log.Print("Cluster project name is invalid")
 		return diag.Errorf("Cluster project name is invalid")
 	}
-	c, err := cluster.GetCluster(clusterName, projectID)
+	c, err := cluster.GetCluster(clusterName, projectID, uaDef)
 	if err != nil {
 		log.Printf("error in get cluster %s", err.Error())
 		if strings.Contains(err.Error(), "not found") {
@@ -6082,7 +6082,7 @@ func resourceEKSClusterRead(ctx context.Context, d *schema.ResourceData, m inter
 	log.Println("got cluster from backend")
 	logger := glogger.GetLogger()
 	rctlCfg := config.GetConfig()
-	clusterSpecYaml, err := clusterctl.GetClusterSpec(logger, rctlCfg, c.Name, projectID)
+	clusterSpecYaml, err := clusterctl.GetClusterSpec(logger, rctlCfg, c.Name, projectID, uaDef)
 	if err != nil {
 		log.Printf("error in get clusterspec %s", err.Error())
 		return diag.FromErr(err)
@@ -6155,7 +6155,7 @@ func resourceEKSClusterUpdate(ctx context.Context, d *schema.ResourceData, m int
 		log.Print("error converting project name to id")
 		return diag.Errorf("error converting project name to project ID")
 	}
-	c, err := cluster.GetCluster(clusterName, projectID)
+	c, err := cluster.GetCluster(clusterName, projectID, uaDef)
 	if err != nil {
 		log.Printf("error in get cluster %s", err.Error())
 		return diag.FromErr(err)
@@ -6186,7 +6186,7 @@ func resourceEKSClusterDelete(ctx context.Context, d *schema.ResourceData, m int
 		return diag.Errorf("error converting project name to project ID")
 	}
 
-	errDel := cluster.DeleteCluster(clusterName, projectID, false)
+	errDel := cluster.DeleteCluster(clusterName, projectID, false, uaDef)
 	if errDel != nil {
 		log.Printf("delete cluster error %s", errDel.Error())
 		return diag.FromErr(errDel)
@@ -6202,7 +6202,7 @@ LOOP:
 			log.Printf("Cluster Deletion for edgename: %s and projectname: %s got timeout out.", clusterName, projectName)
 			return diag.FromErr(fmt.Errorf("cluster deletion for edgename: %s and projectname: %s got timeout out", clusterName, projectName))
 		case <-ticker.C:
-			check, errGet := cluster.GetCluster(clusterName, projectID)
+			check, errGet := cluster.GetCluster(clusterName, projectID, uaDef)
 			if errGet != nil {
 				log.Printf("error while getCluster %s, delete success", errGet.Error())
 				break LOOP
@@ -6261,7 +6261,7 @@ func resourceEKSClusterImport(ctx context.Context, d *schema.ResourceData, meta 
 		return nil, fmt.Errorf("error converting project name to project ID")
 	}
 
-	s, errGet := cluster.GetCluster(clusterName, projectID)
+	s, errGet := cluster.GetCluster(clusterName, projectID, uaDef)
 	if errGet != nil {
 		log.Printf("error while getCluster %s", errGet.Error())
 		return nil, errGet

--- a/rafay/resource_import_cluster.go
+++ b/rafay/resource_import_cluster.go
@@ -226,7 +226,7 @@ func resourceImportClusterCreate(ctx context.Context, d *schema.ResourceData, m 
 	time.Sleep(10 * time.Second)
 	//if error with get cluster add a sleep to wait for cluster creation
 	//make sure new imported cluster was created by calling get cluster and checking for no errors
-	cluster_resp, err := cluster.GetCluster(d.Get("clustername").(string), project_id)
+	cluster_resp, err := cluster.GetCluster(d.Get("clustername").(string), project_id, "")
 	if err != nil {
 		log.Printf("imported cluster was not created, error %s", err.Error())
 		return diag.FromErr(err)
@@ -353,7 +353,7 @@ func resourceImportClusterRead(ctx context.Context, d *schema.ResourceData, m in
 		fmt.Printf("project does not exist")
 		return diags
 	}
-	c, err := cluster.GetCluster(d.Get("clustername").(string), project.ID)
+	c, err := cluster.GetCluster(d.Get("clustername").(string), project.ID, "")
 	if err != nil {
 		log.Printf("error in get cluster %s", err.Error())
 		if strings.Contains(err.Error(), "not found") {
@@ -400,7 +400,7 @@ func resourceImportClusterUpdate(ctx context.Context, d *schema.ResourceData, m 
 	}
 	project_id := p.ID
 	//retrieve cluster_details from get cluster to pass into update cluster
-	cluster_resp, err := cluster.GetCluster(d.Get("clustername").(string), project_id)
+	cluster_resp, err := cluster.GetCluster(d.Get("clustername").(string), project_id, "")
 	if err != nil {
 		log.Printf("imported cluster was not created, error %s", err.Error())
 		return diag.FromErr(err)
@@ -466,7 +466,7 @@ func resourceImportClusterDelete(ctx context.Context, d *schema.ResourceData, m 
 
 	project_id := p.ID
 	//delete cluster once project id is retrieved correctly
-	err = cluster.DeleteCluster(d.Get("clustername").(string), project_id, false)
+	err = cluster.DeleteCluster(d.Get("clustername").(string), project_id, false, "")
 	if err != nil {
 		fmt.Print("cluster was not deleted")
 		log.Printf("cluster was not deleted, error %s", err.Error())

--- a/rafay/resource_workload_cd_operator.go
+++ b/rafay/resource_workload_cd_operator.go
@@ -2069,7 +2069,7 @@ func checkProject(ctx context.Context, project string) (string, []string, error)
 		return "", nil, err
 	}
 
-	clusterList, err := rctl_cluster.ListAllClusters(pr.ID, "")
+	clusterList, err := rctl_cluster.ListAllClusters(pr.ID, "", "")
 	if err != nil {
 		log.Println("failed to list clusters in project ", "error", err)
 	}


### PR DESCRIPTION
Sending user agent for AKS, EKS data and resource APIs. Only sending for aks, eks v1 cluster and cluster sharing resources.

Any cluster request made by other resources like import_cluster and workload cd operator, user agent is set to empty. There is no use of user agent in these these requests.

Jira: https://rafaysystems.atlassian.net/browse/RC-34869

:warning: depends on https://github.com/RafaySystems/rctl/pull/779 (update rctl dependency)