### PR TITLE
RC-37567: Supporting Kubelet Args for MKS Clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ vendor:
 
 .PHONY: update-deps 
 update-deps:
-	GOPRIVATE=github.com/RafaySystems/* go get -d github.com/RafaySystems/rafay-common@master
+	GOPRIVATE=github.com/RafaySystems/* go get -d github.com/RafaySystems/rafay-common@v2.12.x
 
 .PHONY: test-migrate
 test-migrate:

--- a/docs/data-sources/mks_cluster.md
+++ b/docs/data-sources/mks_cluster.md
@@ -79,6 +79,7 @@ Read-Only:
 - `kubernetes_upgrade` (Attributes) (see [below for nested schema](#nestedatt--spec--config--kubernetes_upgrade))
 - `kubernetes_version` (String) Kubernetes version of the Control Plane
 - `installer_ttl` (Integer) By default, this setting allows ttl configuration for installer config. If not provided by default will set ttl to 365 days.
+- `kubelet_extra_args` (Map of String) Cluster kubelet extra args.
 - `location` (String) The data center location where the cluster nodes will be launched
 - `network` (Attributes) MKS Cluster Network Specification (see [below for nested schema](#nestedatt--spec--config--network))
 - `nodes` (Attributes Map) holds node configuration for the cluster (see [below for nested schema](#nestedatt--spec--config--nodes))
@@ -149,6 +150,7 @@ Read-Only:
 - `hostname` (String) Hostname of the node
 - `interface` (String) Interface to be used on the node
 - `labels` (Map of String) labels to be added to the node
+- `kubelet_extra_args` (Map of String) Node kubelet extra args.
 - `operating_system` (String) OS of the node
 - `private_ip` (String) Private ip address of the node
 - `roles` (Set of String) Valid roles are: 'ControlPlane', 'Worker', 'Storage'

--- a/docs/resources/mks_cluster.md
+++ b/docs/resources/mks_cluster.md
@@ -328,6 +328,7 @@ You can change the current Kubernetes version under `spec.config.kubernetes_vers
 **Optional**
 
 - `installer_ttl` (Integer) By default, this setting allows ttl configuration for installer config. If not provided by default will set ttl to 365 days.
+- `kubelet_extra_args` (Map of String) Cluster kubelet extra args.
 - `auto_approve_nodes` (Boolean) By default, this setting allows incoming nodes to be automatically approved. It is recommended to set this option to true to avoid the need for manual approval for each node.
 - `cluster_ssh` (Attributes). The default SSH Local configuration to run bootstrap commands for node discovery. It's required if `spec.cloud_credentials` are not provided(see [below for nested schema](#nestedatt--spec--config--cluster_ssh))
 - `dedicated_control_plane` (Boolean) Select this option for preventing scheduling of user workloads on Control Plane nodes
@@ -382,6 +383,7 @@ You can change the current Kubernetes version under `spec.config.kubernetes_vers
 
 - `interface` (String) Interface to be used on the node
 - `labels` (Map of String) Use Kubernetes labels to control how workloads are scheduled to your nodes.
+- `kubelet_extra_args` (Map of String) Node kubelet extra args.
 - `ssh` (Attributes) Override SSH Config at the node level. This is usefull when nodes within cluster come up with different SSH configuration.(see [below for nested schema](#nestedatt--spec--config--nodes--ssh))
 - `taints` (Attributes Set) A node taint lets you mark a node so that the scheduler avoids or prevents using it for certain Pods. Node taints can be used with tolerations to ensure that Pods aren't scheduled onto inappropriate nodes  (see [below for nested schema](#nestedatt--spec--config--nodes--taints))
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.5
 
 require (
 	github.com/RafaySystems/edge-common v1.24.1-0.20240905053610-494a83a439f8
-	github.com/RafaySystems/rafay-common v1.29.1-rc2.0.20241108093717-9fcd3b59771d
+	github.com/RafaySystems/rafay-common v1.29.1-rc2.0.20241114124339-013c253bd647
 	github.com/RafaySystems/rctl v1.29.1-0.20240930095428-b93a8a4cfea9
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-yaml/yaml v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/RafaySystems/paas-common v0.0.0-20241025204737-6d57f7ed0900 h1:rvzBxW
 github.com/RafaySystems/paas-common v0.0.0-20241025204737-6d57f7ed0900/go.mod h1:cbWiDnN8m1Jpgti3yL39uYW4LTQHHMt5KkTTSRxMcQs=
 github.com/RafaySystems/rafay-common v1.29.1-rc2.0.20241108093717-9fcd3b59771d h1:o8HqZgl3yjvCouOueiY/aTByRRN8iAKzW/5QGNr0caA=
 github.com/RafaySystems/rafay-common v1.29.1-rc2.0.20241108093717-9fcd3b59771d/go.mod h1:1bXZZ44NdKVaKnD6aym1CC/P0/Y+tpeRBXWJs9RwwOw=
+github.com/RafaySystems/rafay-common v1.29.1-rc2.0.20241114124339-013c253bd647 h1:f2yCImaseFZZgsR8nCqQ/7A/HQ9VTY4aICC4FmcOQU4=
+github.com/RafaySystems/rafay-common v1.29.1-rc2.0.20241114124339-013c253bd647/go.mod h1:1bXZZ44NdKVaKnD6aym1CC/P0/Y+tpeRBXWJs9RwwOw=
 github.com/RafaySystems/rctl v1.29.1-0.20240930095428-b93a8a4cfea9 h1:7im+HSvv3QyYOxxo7ovPaeJIzWbBIQskg0T/CfkuyAw=
 github.com/RafaySystems/rctl v1.29.1-0.20240930095428-b93a8a4cfea9/go.mod h1:v8nXVykruedNqmaYF5STEQJoqbvA5rC/378Of+p8XrI=
 github.com/RoaringBitmap/roaring v1.9.4 h1:yhEIoH4YezLYT04s1nHehNO64EKFTop/wBhxv2QzDdQ=

--- a/internal/resource_mks_cluster/mks_cluster_resource_ext.go
+++ b/internal/resource_mks_cluster/mks_cluster_resource_ext.go
@@ -599,6 +599,7 @@ func (v NodesValue) ToHub(ctx context.Context) (*infrapb.MksNode, diag.Diagnosti
 	}
 
 	hub.Labels = convertFromTfMap(v.Labels)
+	hub.KubeletExtraArgs = convertFromTfMap(v.KubeletExtraArgs)
 
 	for _, taint := range v.Taints.Elements() {
 		h, d := taint.(TaintsValue).ToHub(ctx)
@@ -644,6 +645,7 @@ func (v NodesValue) FromHub(ctx context.Context, hub *infrapb.MksNode) (NodesVal
 	if len(hub.Labels) > 0 {
 		v.Labels = convertToTfMap(hub.Labels)
 	}
+	v.KubeletExtraArgs = convertToTfMap(hub.KubeletExtraArgs)
 
 	var tfTaints []attr.Value
 
@@ -696,6 +698,7 @@ func (v ConfigValue) ToHub(ctx context.Context) (*infrapb.MksV3ConfigObject, dia
 	hub.HighAvailability = getBoolValue(v.HighAvailability)
 	hub.KubernetesVersion = getStringValue(v.KubernetesVersion)
 	hub.InstallerTtl = getInt64Value(v.InstallerTtl)
+	hub.KubeletExtraArgs = convertFromTfMap(v.KubeletExtraArgs)
 
 	var networkType NetworkType
 
@@ -751,6 +754,7 @@ func (v ConfigValue) FromHub(ctx context.Context, hub *infrapb.MksV3ConfigObject
 	}
 
 	v.InstallerTtl = types.Int64Value(hub.InstallerTtl)
+	v.KubeletExtraArgs = convertToTfMap(hub.KubeletExtraArgs)
 	v.KubernetesVersion = types.StringValue(hub.KubernetesVersion)
 
 	network, d := NewNetworkValue(v.Network.AttributeTypes(ctx), v.Network.Attributes())

--- a/internal/resource_mks_cluster/mks_cluster_resource_spec.json
+++ b/internal/resource_mks_cluster/mks_cluster_resource_spec.json
@@ -187,6 +187,16 @@
 												}
 											},
 											{
+												"name": "kubelet_extra_args",
+												"map": {
+													"computed_optional_required": "optional",
+													"element_type": {
+														"string": {}
+													},
+													"description": "cluster kubelet extra args"
+												}
+											},
+											{
 												"name": "location",
 												"string": {
 													"computed_optional_required": "optional",
@@ -296,6 +306,16 @@
 																		"string": {}
 																	},
 																	"description": "labels to be added to the node"
+																}
+															},
+															{
+																"name": "kubelet_extra_args",
+																"map": {
+																	"computed_optional_required": "optional",
+																	"element_type": {
+																		"string": {}
+																	},
+																	"description": "node kubelet extra args"
 																}
 															},
 															{


### PR DESCRIPTION
**EPIC Link:**
https://rafaysystems.atlassian.net/browse/RC-37566

**Testing results:**
https://jenkins.qa.stage.rafay-edge.net/job/Developers_Testing/job/master/1861/robot/report/log.html#s1-s1-s1-s13-t1
https://jenkins.qa.stage.rafay-edge.net/job/Developers_Testing/job/master/1863/robot/report/log.html#s1-s1-s1-s1-s1-t1

The test cases "CLI Cluster OCI HA Ubuntu On-prem" and "CLI Cluster AWS HA Ubuntu On-prem" failed because I used the latest master RCTL build, which doesn't yet include my kubelet args changes. Once these changes are merged to QC, these cases will be re-qualified.

Rest all are known issues which we are already working on.
