### PR TITLE
RC-39681: Fixing the, Mks cluster v3 api failing with cert error

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
+	"github.com/RafaySystems/rafay-common/pkg/hub/client/options"
 	"github.com/RafaySystems/rafay-common/pkg/hub/client/typed"
 	config "github.com/RafaySystems/rctl/pkg/config"
 	rctlcontext "github.com/RafaySystems/rctl/pkg/context"
@@ -132,8 +133,7 @@ func (p *RafayFwProvider) Configure(ctx context.Context, req provider.ConfigureR
 	}
 
 	auth := config.GetConfig().GetAppAuthProfile()
-	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, versioninfo.GetUserAgent())
-
+	client, err := typed.NewClientWithUserAgent(auth.URL, auth.Key, versioninfo.GetUserAgent(), options.WithInsecureSkipVerify(auth.SkipServerCertValid))
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to initialise the Client, Error", err.Error())
 		return


### PR DESCRIPTION
https://rafaysystems.atlassian.net/browse/RC-39681

**Test result:**

`rafay_mks_cluster.mks-sample-cluster: Creating... ╷ │ Error: Client Error │  │   with rafay_mks_cluster.mks-sample-cluster, │   on main.tf line 15, in resource "rafay_mks_cluster" "mks-sample-cluster": │   15: resource "rafay_mks_cluster" "mks-sample-cluster" { │  │ Unable to create cluster, got error: cluster Apply failed: unable to complete request code 404, body {"internal":"unable to hydrate │ options rpc error: code = NotFound desc = unable to get project rpc error: code = NotFound desc = ","code":1,"external":"Not Found"} │  ╵`