### PR TITLE
Rc xxxx remove proxy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
                     export GOLANG_PROTOBUF_REGISTRATION_CONFLICT=ignore
                     echo machine github.com login ${userName} password ${passWord} > ~/.netrc
                     chmod 400 ~/.netrc
-                    GOPROXY="direct" GOPRIVATE="github.com/RafaySystems/*" go mod download
+                    GOPRIVATE="github.com/RafaySystems/*" go mod download
                     make release
                     make push
                     make bucket-name

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
                     export GOLANG_PROTOBUF_REGISTRATION_CONFLICT=ignore
                     echo machine github.com login ${userName} password ${passWord} > ~/.netrc
                     chmod 400 ~/.netrc
-                    GOPRIVATE="github.com/RafaySystems/*" go mod download
+                    GOPROXY="https://proxy.golang.org,direct" GOPRIVATE="github.com/RafaySystems/*" go mod download
                     make release
                     make push
                     make bucket-name


### PR DESCRIPTION
Fixes:
```
> GOPROXY="direct" GOPRIVATE="github.com/RafaySystems/*" go mod download
go: github.com/grpc-ecosystem/grpc-gateway@v1.16.0 requires
        golang.org/x/oauth2@v0.0.0-20200107190931-bf48bf16ab8d requires
        cloud.google.com/go@v0.34.0 requires
        go.opencensus.io@v0.23.0: unrecognized import path "go.opencensus.io": https fetch: Get "https://go.opencensus.io/?go-get=1": tls: failed to verify certificate: x509: certificate has expired or is not yet valid: “go.opencensus.io” certificate is expired
```