### PR TITLE
RC-39824: Fixing the, kubelet_extra_args field missing in the mks terraform data schema causing attribute error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ zip:
 	$(shell cd bin; zip ${BINARY}_${VERSION}_darwin_amd64.zip ${BINARY}_${VERSION}_darwin_amd64)
 
 install: build
+	bash internal/scripts/fwgen.sh
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 

--- a/internal/provider/mks_cluster_data_source.go
+++ b/internal/provider/mks_cluster_data_source.go
@@ -164,6 +164,11 @@ func MksClusterDataSourceSchema(ctx context.Context) schema.Schema {
 								Computed:    true,
 								Description: "Installer TTL Configuration",
 							},
+							"kubelet_extra_args": schema.MapAttribute{
+								ElementType: types.StringType,
+								Computed:    true,
+								Description: "Cluster kubelet extra args",
+							},
 							"location": schema.StringAttribute{
 								Computed:    true,
 								Description: "The data center location where the cluster nodes will be launched",
@@ -243,6 +248,11 @@ func MksClusterDataSourceSchema(ctx context.Context) schema.Schema {
 											ElementType: types.StringType,
 											Computed:    true,
 											Description: "labels to be added to the node",
+										},
+										"kubelet_extra_args": schema.MapAttribute{
+											ElementType: types.StringType,
+											Computed:    true,
+											Description: "Node kubelet extra args",
 										},
 										"operating_system": schema.StringAttribute{
 											Computed:    true,
@@ -538,6 +548,7 @@ func (d *MksClusterDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		resp.Diagnostics.AddError("Failed to fetch data", err.Error())
 		return
 	}
+
 	// convert the hub respo into the TF model
 	resp.Diagnostics.Append(fw.ConvertMksClusterFromHub(ctx, hub, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/resource_mks_cluster/mks_cluster_resource_ext.go
+++ b/internal/resource_mks_cluster/mks_cluster_resource_ext.go
@@ -61,6 +61,10 @@ func convertFromTfMap(tfMap types.Map) map[string]string {
 }
 
 func convertToTfMap(goMap map[string]string) types.Map {
+	if goMap == nil || len(goMap) == 0 {
+		return types.MapNull(types.StringType)
+	}
+
 	elements := make(map[string]attr.Value)
 
 	for k, v := range goMap {
@@ -675,12 +679,8 @@ func (v NodesValue) FromHub(ctx context.Context, hub *infrapb.MksNode) (NodesVal
 	v.Roles, d = types.SetValue(types.StringType, tfRoles)
 	diags = append(diags, d...)
 
-	if len(hub.Labels) > 0 {
-		v.Labels = convertToTfMap(hub.Labels)
-	}
-
+	v.Labels = convertToTfMap(hub.Labels)
 	v.KubeletExtraArgs = convertToTfMap(hub.KubeletExtraArgs)
-
 	var tfTaints []attr.Value
 
 	tfTaintsType := TaintsType{
@@ -788,7 +788,9 @@ func (v ConfigValue) FromHub(ctx context.Context, hub *infrapb.MksV3ConfigObject
 	}
 
 	v.InstallerTtl = types.Int64Value(hub.InstallerTtl)
+
 	v.KubeletExtraArgs = convertToTfMap(hub.KubeletExtraArgs)
+
 	v.KubernetesVersion = types.StringValue(hub.KubernetesVersion)
 
 	network, d := NewNetworkValue(v.Network.AttributeTypes(ctx), v.Network.Attributes())


### PR DESCRIPTION
**Bug link:**
https://rafaysystems.atlassian.net/browse/RC-39824