### PR TITLE
RC-40725 Fix blueprint terraform diff

### DIFF
--- a/rafay/resource_blueprint.go
+++ b/rafay/resource_blueprint.go
@@ -211,6 +211,10 @@ func resourceBluePrintRead(ctx context.Context, d *schema.ResourceData, m interf
 	if tfBlueprintState.Spec != nil && tfBlueprintState.Spec.Sharing != nil && !tfBlueprintState.Spec.Sharing.Enabled && bp.Spec.Sharing == nil {
 		bp.Spec.Sharing = &commonpb.SharingSpec{}
 		bp.Spec.Sharing.Enabled = false
+		bp.Spec.Sharing.Projects = tfBlueprintState.Spec.Sharing.Projects
+	}
+	if tfBlueprintState.Spec != nil && tfBlueprintState.Spec.NamespaceConfig != nil && bp.Spec != nil && bp.Spec.NamespaceConfig != nil {
+		bp.Spec.NamespaceConfig.SyncType = tfBlueprintState.Spec.NamespaceConfig.SyncType
 	}
 
 	// XXX Debug

--- a/rafay/resource_blueprint.go
+++ b/rafay/resource_blueprint.go
@@ -213,11 +213,6 @@ func resourceBluePrintRead(ctx context.Context, d *schema.ResourceData, m interf
 		bp.Spec.Sharing.Enabled = false
 		bp.Spec.Sharing.Projects = tfBlueprintState.Spec.Sharing.Projects
 	}
-	if tfBlueprintState.Spec != nil && tfBlueprintState.Spec.NamespaceConfig != nil && bp.Spec != nil && bp.Spec.NamespaceConfig != nil {
-		if strings.EqualFold(tfBlueprintState.Spec.NamespaceConfig.SyncType, bp.Spec.NamespaceConfig.SyncType) {
-			bp.Spec.NamespaceConfig.SyncType = tfBlueprintState.Spec.NamespaceConfig.SyncType
-		}
-	}
 
 	// XXX Debug
 	// w1 = spew.Sprintf("%+v", wl)

--- a/rafay/resource_blueprint.go
+++ b/rafay/resource_blueprint.go
@@ -214,7 +214,9 @@ func resourceBluePrintRead(ctx context.Context, d *schema.ResourceData, m interf
 		bp.Spec.Sharing.Projects = tfBlueprintState.Spec.Sharing.Projects
 	}
 	if tfBlueprintState.Spec != nil && tfBlueprintState.Spec.NamespaceConfig != nil && bp.Spec != nil && bp.Spec.NamespaceConfig != nil {
-		bp.Spec.NamespaceConfig.SyncType = tfBlueprintState.Spec.NamespaceConfig.SyncType
+		if strings.EqualFold(tfBlueprintState.Spec.NamespaceConfig.SyncType, bp.Spec.NamespaceConfig.SyncType) {
+			bp.Spec.NamespaceConfig.SyncType = tfBlueprintState.Spec.NamespaceConfig.SyncType
+		}
 	}
 
 	// XXX Debug


### PR DESCRIPTION
- If sharing is disabled we don't store projects list in backend, if user is providing project list with sharing disabled then we need to ignore it in terraform provider also to avoid diff in plan
- Namespace Config Sync Type is case insensitive in rafay-hub but we stored only "Managed", "Unmanaged" in database which causes diff in terraform, need to make it case insesitive in terraform provider

Test Done 
- Created blueprint with the spec mentioned in testcase with terraform apply
- No diff on terraform plan after apply