### PR TITLE
RC-41055 - handle defaults inside monitoring struct of blueprint

### DIFF
--- a/rafay/resource_blueprint.go
+++ b/rafay/resource_blueprint.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -214,6 +215,26 @@ func resourceBluePrintRead(ctx context.Context, d *schema.ResourceData, m interf
 		if tfBlueprintState.Spec.DefaultAddons.EnableMonitoring {
 			if tfBlueprintState.Spec.DefaultAddons.Monitoring == nil && bp.Spec.DefaultAddons.Monitoring != nil {
 				bp.Spec.DefaultAddons.Monitoring = nil
+			}
+			if tfBlueprintState.Spec.DefaultAddons.Monitoring != nil && bp.Spec.DefaultAddons.Monitoring != nil {
+				if tfBlueprintState.Spec.DefaultAddons.Monitoring.GpuOperator == nil &&
+					reflect.DeepEqual(bp.Spec.DefaultAddons.Monitoring.GpuOperator, &infrapb.MonitoringComponent{}) {
+					bp.Spec.DefaultAddons.Monitoring.GpuOperator = nil
+				}
+				if tfBlueprintState.Spec.DefaultAddons.Monitoring.MetricsServer == nil &&
+					reflect.DeepEqual(bp.Spec.DefaultAddons.Monitoring.MetricsServer, &infrapb.MonitoringComponent{
+						Enabled:              false,
+						CustomizationEnabled: true,
+					}) {
+					bp.Spec.DefaultAddons.Monitoring.MetricsServer = nil
+				}
+				if tfBlueprintState.Spec.DefaultAddons.Monitoring.PrometheusAdapter == nil &&
+					reflect.DeepEqual(bp.Spec.DefaultAddons.Monitoring.PrometheusAdapter, &infrapb.MonitoringComponent{
+						Enabled:              false,
+						CustomizationEnabled: true,
+					}) {
+					bp.Spec.DefaultAddons.Monitoring.PrometheusAdapter = nil
+				}
 			}
 		}
 	}

--- a/rafay/resource_blueprint.go
+++ b/rafay/resource_blueprint.go
@@ -213,7 +213,27 @@ func resourceBluePrintRead(ctx context.Context, d *schema.ResourceData, m interf
 	}
 	if tfBlueprintState.Spec != nil && tfBlueprintState.Spec.DefaultAddons != nil && bp.Spec != nil && bp.Spec.DefaultAddons != nil {
 		if tfBlueprintState.Spec.DefaultAddons.EnableMonitoring {
-			if tfBlueprintState.Spec.DefaultAddons.Monitoring == nil && bp.Spec.DefaultAddons.Monitoring != nil {
+			if tfBlueprintState.Spec.DefaultAddons.Monitoring == nil &&
+				tfBlueprintState.Spec.Type == "default-aks" &&
+				reflect.DeepEqual(bp.Spec.DefaultAddons.Monitoring, &infrapb.MonitoringConfig{
+					GpuOperator: &infrapb.MonitoringComponent{},
+					MetricsServer: &infrapb.MonitoringComponent{
+						Enabled:              false,
+						CustomizationEnabled: true,
+					},
+					PrometheusAdapter: &infrapb.MonitoringComponent{
+						Enabled:              false,
+						CustomizationEnabled: true,
+					},
+				}) {
+
+				bp.Spec.DefaultAddons.Monitoring = nil
+			}
+			if tfBlueprintState.Spec.DefaultAddons.Monitoring == nil &&
+				tfBlueprintState.Spec.Type == "default" &&
+				reflect.DeepEqual(bp.Spec.DefaultAddons.Monitoring, &infrapb.MonitoringConfig{
+					GpuOperator: &infrapb.MonitoringComponent{},
+				}) {
 				bp.Spec.DefaultAddons.Monitoring = nil
 			}
 			if tfBlueprintState.Spec.DefaultAddons.Monitoring != nil && bp.Spec.DefaultAddons.Monitoring != nil {


### PR DESCRIPTION
- test tried out to terraform apply and terraform plan on the spec mentioned in this ticket https://rafaysystems.atlassian.net/browse/RC-41055



Below is the defaults which comes up in terraform plan 
  ~ resource "rafay_blueprint" "blueprint" {
        id = "custom-bp-aks-736340815"

      ~ spec {
            # (3 unchanged attributes hidden)

          ~ default_addons {
                # (7 unchanged attributes hidden)

              - monitoring {
                  - gpu_operator {
                    }
                  - metrics_server {
                      - customization_enabled = true -> null
                      - enabled               = false -> null
                    }
                  - prometheus_adapter {
                      - customization_enabled = true -> null
                      - enabled               = false -> null
                    }
                }
            }

            # (14 unchanged blocks hidden)
        }

        # (1 unchanged block hidden)
    }