### PR TITLE
fix reapply with opentofu destroy init hook

### DIFF
--- a/rafay/resource_resourcetemplate.go
+++ b/rafay/resource_resourcetemplate.go
@@ -1679,7 +1679,7 @@ func flattenOpenTofuDestroyHooks(input *eaaspb.OpenTofuDestroyHooks, p []any) []
 	obj["plan"] = flattenLifecycleEventHooks(input.Plan, v)
 
 	v, _ = obj["destroy"].([]any)
-	obj["apply"] = flattenLifecycleEventHooks(input.Destroy, v)
+	obj["destroy"] = flattenLifecycleEventHooks(input.Destroy, v)
 
 	return []any{obj}
 }


### PR DESCRIPTION
Fixes

[Re-applying Terraform for resource templates with destroy opentofu hooks gives error](https://rafaysystems.atlassian.net/browse/RC-41568)