### PR TITLE
RC-36528: Upgrading MKS Components CRI, ETCD and Salt Minion via Platform Version

### DIFF
--- a/docs/data-sources/mks_cluster.md
+++ b/docs/data-sources/mks_cluster.md
@@ -80,6 +80,7 @@ Read-Only:
 - `kubernetes_version` (String) Kubernetes version of the Control Plane
 - `installer_ttl` (Integer) By default, this setting allows ttl configuration for installer config. If not provided by default will set ttl to 365 days.
 - `kubelet_extra_args` (Map of String) Cluster kubelet extra args.
+- `platform_version` (String) Platform version that allows upgrading the cluster's internal components.
 - `location` (String) The data center location where the cluster nodes will be launched
 - `network` (Attributes) MKS Cluster Network Specification (see [below for nested schema](#nestedatt--spec--config--network))
 - `nodes` (Attributes Map) holds node configuration for the cluster (see [below for nested schema](#nestedatt--spec--config--nodes))

--- a/docs/resources/mks_cluster.md
+++ b/docs/resources/mks_cluster.md
@@ -26,7 +26,8 @@ resource "rafay_mks_cluster" "mks-noha-converged-cluster" {
     config = {
       auto_approve_nodes      = true
       kubernetes_version      = "v1.28.9"
-      installer_ttl            = 365
+      installer_ttl           = 365
+      platform_version        = "v1.0.0"
       network = {
         cni = {
           name    = "Calico"
@@ -80,6 +81,7 @@ resource "rafay_mks_cluster" "mks-ha-cluster" {
       high_availability       = true
       kubernetes_version      = "v1.28.9"
       installer_ttl           = 365
+      platform_version        = "v1.0.0"
       kubernetes_upgrade = {
         strategy = "sequential"
         params = {
@@ -157,6 +159,7 @@ resource "rafay_mks_cluster" "mks-ha-cluster-with-dedicated-cp" {
       dedicated_control_plane = true
       kubernetes_version      = "v1.28.9"
       installer_ttl           = 365
+      platform_version        = "v1.0.0"
       kubernetes_upgrade = {
         strategy = "sequential"
         params = {
@@ -335,6 +338,7 @@ You can change the current Kubernetes version under `spec.config.kubernetes_vers
 - `high_availability` (Boolean) Select this option for highly available control plane. Minimum three control plane nodes are required
 - `kubernetes_upgrade` (Attributes) Strategize the Kubernetes upgrade behaviour among the worker nodes (see [below for nested schema](#nestedatt--spec--config--kubernetes_upgrade))
 - `location` (String) The data center location where the cluster nodes will be launched
+- `platform_version` (String) Platform version that allows upgrading the cluster's internal components.
 
 <a id="nestedatt--spec--config--network"></a>
 ### Nested Schema for `spec.config.network`

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.4
 
 require (
 	github.com/RafaySystems/edge-common v1.24.1-0.20240905053610-494a83a439f8
-	github.com/RafaySystems/rafay-common v1.29.1-rc2.0.20250428214633-391c4a2057fe
+	github.com/RafaySystems/rafay-common v1.29.1-rc2.0.20250502191542-dcf6087ea401
 	github.com/RafaySystems/rctl v1.29.1-0.20250417080812-e603443955d7
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-yaml/yaml v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -22,10 +22,8 @@ github.com/RafaySystems/edge-common v1.24.1-0.20240905053610-494a83a439f8 h1:Pce
 github.com/RafaySystems/edge-common v1.24.1-0.20240905053610-494a83a439f8/go.mod h1:5mRn2xN25Y8mpObHyOwDB3OLudeuglzHTQX9IiNHxhM=
 github.com/RafaySystems/paas-common v0.0.0-20250407132001-0d707c610b95 h1:3z1arMhSoXGTwtYV8jFGsfJh/IhjaZ8X1exoXHSc5oc=
 github.com/RafaySystems/paas-common v0.0.0-20250407132001-0d707c610b95/go.mod h1:vDR0S28Q+hwE/5wO0L/Ohn9CZwaI/o2QuPupJ2iLI7k=
-github.com/RafaySystems/rafay-common v1.29.1-rc2.0.20250428055418-c6c816d4931c h1:Os8CI0eZePNy5mxuNfOXlOLk3silkfpQvG0DXnLwhk4=
-github.com/RafaySystems/rafay-common v1.29.1-rc2.0.20250428055418-c6c816d4931c/go.mod h1:dQQiBxFlzDhUsa9LD2fZwHpKXWCmfr5IKpuj4xfCRtE=
-github.com/RafaySystems/rafay-common v1.29.1-rc2.0.20250428214633-391c4a2057fe h1:XCX7WWBxYXnndCzoMbasDqlpHDqlp60uwGJCIk0m4a8=
-github.com/RafaySystems/rafay-common v1.29.1-rc2.0.20250428214633-391c4a2057fe/go.mod h1:dQQiBxFlzDhUsa9LD2fZwHpKXWCmfr5IKpuj4xfCRtE=
+github.com/RafaySystems/rafay-common v1.29.1-rc2.0.20250502191542-dcf6087ea401 h1:gEL8X6k96LdyZ2Io+U1ImOWYXcl557JnFviljc/9HGc=
+github.com/RafaySystems/rafay-common v1.29.1-rc2.0.20250502191542-dcf6087ea401/go.mod h1:dQQiBxFlzDhUsa9LD2fZwHpKXWCmfr5IKpuj4xfCRtE=
 github.com/RafaySystems/rctl v1.29.1-0.20250417080812-e603443955d7 h1:uk8kF29oYdj7OE1zkNSA52+FmccCWYKCEJBYKf/PEsA=
 github.com/RafaySystems/rctl v1.29.1-0.20250417080812-e603443955d7/go.mod h1:KjsJ54G1zmsdT9UodQ54BKAbuJAj5ufd82Ol6i3bifM=
 github.com/RoaringBitmap/roaring v1.9.4 h1:yhEIoH4YezLYT04s1nHehNO64EKFTop/wBhxv2QzDdQ=

--- a/internal/resource_mks_cluster/mks_cluster_resource_ext.go
+++ b/internal/resource_mks_cluster/mks_cluster_resource_ext.go
@@ -735,6 +735,7 @@ func (v ConfigValue) ToHub(ctx context.Context) (*infrapb.MksV3ConfigObject, dia
 	hub.KubernetesVersion = getStringValue(v.KubernetesVersion)
 	hub.InstallerTtl = getInt64Value(v.InstallerTtl)
 	hub.KubeletExtraArgs = convertFromTfMap(v.KubeletExtraArgs)
+	hub.PlatformVersion = getStringValue(v.PlatformVersion)
 
 	var networkType NetworkType
 
@@ -794,6 +795,8 @@ func (v ConfigValue) FromHub(ctx context.Context, hub *infrapb.MksV3ConfigObject
 	v.KubeletExtraArgs = convertToTfMap(hub.KubeletExtraArgs)
 
 	v.KubernetesVersion = types.StringValue(hub.KubernetesVersion)
+
+	v.PlatformVersion = types.StringValue(hub.PlatformVersion)
 
 	network, d := NewNetworkValue(v.Network.AttributeTypes(ctx), v.Network.Attributes())
 	if d.HasError() {

--- a/internal/resource_mks_cluster/mks_cluster_resource_spec.json
+++ b/internal/resource_mks_cluster/mks_cluster_resource_spec.json
@@ -187,6 +187,13 @@
 												}
 											},
 											{
+												"name": "platform_version",
+												"string": {
+													"computed_optional_required": "required",
+													"description": "Platform version configuration"
+												}
+											},
+											{
 												"name": "kubelet_extra_args",
 												"map": {
 													"computed_optional_required": "optional",


### PR DESCRIPTION
**EPIC Link:**
https://rafaysystems.atlassian.net/browse/RC-36527

**Regression reports:**

**AWS API report:**
https://jenkins.qa.stage.rafay-edge.net/job/Developers_Testing/job/master/2144/robot/report/log.html#s1-s1-s1-s1-t1

**OCI API report:**
https://jenkins.qa.stage.rafay-edge.net/job/Developers_Testing/job/master/2143/robot/report/log.html#s1-s1-s1-s17

**Summary of Findings:**
There are no critical failures in the provisioning flow. Most of the observed issues are related to workload deployment failures post-provisioning. This problem has been consistently observed across multiple regression runs.

**Error message:** 
```
Workload publish status:Failed with error:cluster rauto-ocialmalinux-960585881: Install failed : 1 error occurred:
	* services "workloadrauto-849963063-wordpress" is forbidden: exceeded quota: namespace-849963063-resource-quota, requested: services.nodeports=2, used: services.nodeports=0, limited: services.nodeports=0
```
Reported this issue with platform team, they are already working on it.

**Detailed Observations:**

**OCI:**

Two provisioning flows failed: OCI Ubuntu (Canal) and OCI Ubuntu (Calico).

These cases were validated locally and are working fine, indicating likely environment-specific issues in the regression setup.

**AWS:**

Windows cases are failing due to outdated launch templates. This is a known issue tracked under the rauto component.

The no-HA RHEL7 case fails because RHEL7 has reached End of Life (EOL) and is incompatible with containerd v2.0.x, which is now used by default.

We are planning to remove the support for RHEL7 from 3.5 release.

The Ubuntu 24.04 with Cilium case provisions successfully, but the blueprint sync fails. This works correctly in local validation, pointing again to possible environmental differences or timing issues.

**Note:** 
Only API cases can be tested for this feature, because of dependency issues with RCTL and terraform while building.
Once this feature is merged we will have one round of full regression on testbeds and if there is any issues will fix it in the earliest

