### PR TITLE
RC-42498: Fixing, Backward compatibility issue- Expecting platform_version argument for the older clusters

### DIFF
--- a/internal/resource_mks_cluster/mks_cluster_resource_spec.json
+++ b/internal/resource_mks_cluster/mks_cluster_resource_spec.json
@@ -189,7 +189,7 @@
 											{
 												"name": "platform_version",
 												"string": {
-													"computed_optional_required": "required",
+													"computed_optional_required": "optional",
 													"description": "Platform version configuration"
 												}
 											},


### PR DESCRIPTION
**Bug link:**
https://rafaysystems.atlassian.net/browse/RC-42498

**RCA:**
Making the string as Optional, before it use to be required.

**Manual testing:**
```
manish@manish-C02F53B1MD6M rafay_mks_cluster % tf plan
rafay_mks_cluster.mks-noha-converged-cluster: Refreshing state...

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```