### PR TITLE
RC-42590

### DIFF
--- a/internal/resource_mks_cluster/mks_cluster_resource_ext.go
+++ b/internal/resource_mks_cluster/mks_cluster_resource_ext.go
@@ -789,14 +789,15 @@ func (v ConfigValue) FromHub(ctx context.Context, hub *infrapb.MksV3ConfigObject
 	if hub.HighAvailability {
 		v.HighAvailability = types.BoolValue(hub.HighAvailability)
 	}
+	if hub.PlatformVersion != "" {
+		v.PlatformVersion = types.StringValue(hub.PlatformVersion)
+	}
 
 	v.InstallerTtl = types.Int64Value(hub.InstallerTtl)
 
 	v.KubeletExtraArgs = convertToTfMap(hub.KubeletExtraArgs)
 
 	v.KubernetesVersion = types.StringValue(hub.KubernetesVersion)
-
-	v.PlatformVersion = types.StringValue(hub.PlatformVersion)
 
 	network, d := NewNetworkValue(v.Network.AttributeTypes(ctx), v.Network.Attributes())
 	if d.HasError() {


### PR DESCRIPTION
**Bug link:**
https://rafaysystems.atlassian.net/browse/RC-42590?linkSource=email

**RCA:**
Added validation to handle scenarios where the platform version is empty during the Terraform plan phase, post cluster provisioning.

**Manual testing has been done along with this fix:**
```
(3.9.1) manish@manish-C02F53B1MD6M rafay_mks_cluster % tf plan
rafay_mks_cluster.mks-noha-converged-cluster: Refreshing state...

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```