### PR TITLE
RC-48342: Fix ZonalShiftConfig.Enabled bool+omitempty dropping false on disable

### DIFF
--- a/internal/resource_eks_cluster/eks_cluster_resource_expand.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_expand.go
@@ -2425,7 +2425,8 @@ func (v ZonalShiftConfigValue) Expand(ctx context.Context) (*rafay.ZonalShiftCon
 	}
 
 	if !v.Enabled.IsNull() && !v.Enabled.IsUnknown() {
-		zsc.Enabled = getBoolValue(v.Enabled)
+		b := getBoolValue(v.Enabled)
+		zsc.Enabled = &b
 	}
 
 	return &zsc, diags

--- a/internal/resource_eks_cluster/eks_cluster_resource_expand.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_expand.go
@@ -2441,7 +2441,8 @@ func (v AutoZonalShiftConfigValue) Expand(ctx context.Context) (*rafay.AutoZonal
 	}
 
 	if !v.Enabled.IsNull() && !v.Enabled.IsUnknown() {
-		azsc.Enabled = getBoolValue(v.Enabled)
+		b := getBoolValue(v.Enabled)
+		azsc.Enabled = &b
 	}
 
 	listFromListValue := func(lv basetypes.ListValue) []string {

--- a/internal/resource_eks_cluster/eks_cluster_resource_flatten.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_flatten.go
@@ -770,7 +770,9 @@ func (v *AutoZonalShiftConfigValue) Flatten(ctx context.Context, in *rafay.AutoZ
 	if in == nil {
 		return diags
 	}
-	v.Enabled = types.BoolValue(in.Enabled)
+	if in.Enabled != nil {
+		v.Enabled = types.BoolValue(*in.Enabled)
+	}
 
 	listFromStrings := func(sl []string) basetypes.ListValue {
 		if len(sl) == 0 {

--- a/internal/resource_eks_cluster/eks_cluster_resource_flatten.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_flatten.go
@@ -758,7 +758,9 @@ func (v *ZonalShiftConfigValue) Flatten(ctx context.Context, in *rafay.ZonalShif
 	if in == nil {
 		return diags
 	}
-	v.Enabled = types.BoolValue(in.Enabled)
+	if in.Enabled != nil {
+		v.Enabled = types.BoolValue(*in.Enabled)
+	}
 	v.state = attr.ValueStateKnown
 	return diags
 }

--- a/rafay/eks_config.go
+++ b/rafay/eks_config.go
@@ -83,7 +83,7 @@ type ZonalShiftConfig struct {
 }
 
 type AutoZonalShiftConfig struct {
-	Enabled        bool     `yaml:"enabled,omitempty"`
+	Enabled        *bool    `yaml:"enabled,omitempty"`
 	AllowedWindows []string `yaml:"allowedWindows,omitempty"`
 	BlockedDates   []string `yaml:"blockedDates,omitempty"`
 	BlockedWindows []string `yaml:"blockedWindows,omitempty"`

--- a/rafay/eks_config.go
+++ b/rafay/eks_config.go
@@ -79,7 +79,7 @@ type EKSClusterConfig struct {
 }
 
 type ZonalShiftConfig struct {
-	Enabled bool `yaml:"enabled,omitempty"`
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 type AutoZonalShiftConfig struct {


### PR DESCRIPTION


When disabling zonal shift (enabled=false), Go's omitempty silently dropped the false zero value during YAML serialization, sending zonalShiftConfig: {} to the server. The server's diff manager calls GetBoolean("enabled") which returns a 400 "Field not found" when the field is absent.

Fix: change Enabled from bool to *bool so omitempty only omits when nil (genuinely unset), not when explicitly set to false. Update Expand to take the address of the bool value, and Flatten to dereference the pointer.

PRs to be merged only after checking all these items:
- [ ] terraform schema update
- [ ] terraform docs update
- [ ] backward compatibilty test
