### PR TITLE
RC-49338: Treat 404/not-found as drift across legacy SDKv2 resources (cherry-pick to v4.2.x)

### DIFF
--- a/rafay/resource_access_apikey.go
+++ b/rafay/resource_access_apikey.go
@@ -181,6 +181,11 @@ func resourceAccessApiRead(ctx context.Context, d *schema.ResourceData, m interf
 		ua, err := user.GetUser(userName)
 		if err != nil {
 			log.Printf("get user account, error %s", err.Error())
+			if IsResourceNotFoundErr(err) {
+				log.Println("resourceAccessApiRead: user not found, treating as drift", "error", err)
+				d.SetId("")
+				return diags
+			}
 			return diag.FromErr(err)
 		}
 		userAccount = *ua

--- a/rafay/resource_aks_cluster.go
+++ b/rafay/resource_aks_cluster.go
@@ -7103,6 +7103,11 @@ func resourceAKSClusterRead(ctx context.Context, d *schema.ResourceData, m inter
 	clusterSpec, err := getDeployedClusterSpec(ctx, d)
 	if err != nil {
 		log.Printf("error in get cluster spec %s", err.Error())
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceAKSClusterRead: cluster not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 
@@ -7154,11 +7159,6 @@ func getDeployedClusterSpec(ctx context.Context, d *schema.ResourceData) (*AKSCl
 	c, err := cluster.GetCluster(clusterName, projectId, uaDef)
 	if err != nil {
 		log.Printf("error in get cluster %s", err.Error())
-		if strings.Contains(err.Error(), "not found") {
-			log.Println("Resource Read ", "error", err)
-			d.SetId("")
-			return clusterSpec, fmt.Errorf("resource read failed, cluster not found. Error: %s", err.Error())
-		}
 		return clusterSpec, err
 	}
 

--- a/rafay/resource_aks_cluster_v3.go
+++ b/rafay/resource_aks_cluster_v3.go
@@ -64,6 +64,12 @@ func resourceAKSClusterV3Read(ctx context.Context, d *schema.ResourceData, m int
 
 	deployedCluster, err := getDeployedClusterSpecV3(ctx, d)
 	if err != nil {
+		log.Printf("resourceAKSClusterV3Read get cluster error %s", err.Error())
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceAKSClusterV3Read: cluster not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 

--- a/rafay/resource_alertconfig.go
+++ b/rafay/resource_alertconfig.go
@@ -124,6 +124,11 @@ func resourceAlertConfigRead(ctx context.Context, d *schema.ResourceData, m inte
 	})
 	if err != nil {
 		log.Println("read get err")
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceAlertConfigRead: resource not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 

--- a/rafay/resource_breakglassaccess.go
+++ b/rafay/resource_breakglassaccess.go
@@ -186,6 +186,11 @@ func resourceBreakGlassAccessRead(ctx context.Context, d *schema.ResourceData, m
 	})
 	if err != nil {
 		log.Println("read get err")
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceBreakGlassAccessRead: resource not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 

--- a/rafay/resource_chargeback_common_services_policy.go
+++ b/rafay/resource_chargeback_common_services_policy.go
@@ -150,6 +150,12 @@ func resourceChargebackCommonServicesPolicyRead(ctx context.Context, d *schema.R
 		Project: tfChargebackCommonServicesPolicyState.Metadata.Project,
 	})
 	if err != nil {
+		log.Printf("resourceChargebackCommonServicesPolicyRead get error %s", err.Error())
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceChargebackCommonServicesPolicyRead: resource not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 

--- a/rafay/resource_chargeback_group.go
+++ b/rafay/resource_chargeback_group.go
@@ -150,6 +150,12 @@ func resourceChargebackGroupRead(ctx context.Context, d *schema.ResourceData, m 
 		Project: tfChargebackGroupState.Metadata.Project,
 	})
 	if err != nil {
+		log.Printf("resourceChargebackGroupRead get error %s", err.Error())
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceChargebackGroupRead: resource not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 

--- a/rafay/resource_chargeback_group_report.go
+++ b/rafay/resource_chargeback_group_report.go
@@ -153,6 +153,12 @@ func resourceChargebackGroupReportRead(ctx context.Context, d *schema.ResourceDa
 		Project: tfChargebackGroupReportState.Metadata.Project,
 	})
 	if err != nil {
+		log.Printf("resourceChargebackGroupReportRead get error %s", err.Error())
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceChargebackGroupReportRead: resource not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 

--- a/rafay/resource_chargeback_share.go
+++ b/rafay/resource_chargeback_share.go
@@ -151,6 +151,12 @@ func resourceChargebackShareRead(ctx context.Context, d *schema.ResourceData, m 
 		Project: tfChargebackShareState.Metadata.Project,
 	})
 	if err != nil {
+		log.Printf("resourceChargebackShareRead get error %s", err.Error())
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceChargebackShareRead: resource not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 

--- a/rafay/resource_cloud_credential.go
+++ b/rafay/resource_cloud_credential.go
@@ -157,10 +157,12 @@ func resourceCloudCredentialRead(ctx context.Context, d *schema.ResourceData, m 
 	c, err := cloudprovider.GetCloudProvider(d.Get("name").(string), project.ID)
 	if err != nil {
 		log.Printf("failed to get cloud provider %s", err.Error())
-		//return diag.FromErr(err)
-		if err := d.Set("name", c.Name); err != nil {
-			d.Set("name", "")
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceCloudCredentialRead: cloud provider not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
 		}
+		return diag.FromErr(err)
 	}
 	if err := d.Set("name", c.Name); err != nil {
 		log.Printf("get cloud credential set name error %s", err.Error())

--- a/rafay/resource_container_registry.go
+++ b/rafay/resource_container_registry.go
@@ -216,6 +216,12 @@ func resourceContainerRegistryRead(ctx context.Context, d *schema.ResourceData, 
 		Project: containerRegistry.Metadata.Project,
 	})
 	if err != nil {
+		log.Printf("resourceContainerRegistryRead get error %s", err.Error())
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceContainerRegistryRead: resource not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 	log.Println("read get 2")

--- a/rafay/resource_customrole.go
+++ b/rafay/resource_customrole.go
@@ -162,6 +162,11 @@ func resourceCustomRoleRead(ctx context.Context, d *schema.ResourceData, m inter
 	})
 	if err != nil {
 		log.Println("read get err")
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceCustomRoleRead: resource not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 

--- a/rafay/resource_eks_cluster.go
+++ b/rafay/resource_eks_cluster.go
@@ -6984,10 +6984,10 @@ func resourceEKSClusterRead(ctx context.Context, d *schema.ResourceData, m inter
 	c, err := cluster.GetCluster(clusterName, projectID, uaDef)
 	if err != nil {
 		log.Printf("error in get cluster %s", err.Error())
-		if strings.Contains(err.Error(), "not found") {
-			log.Println("Resource Read ", "error", err)
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceEKSClusterRead: cluster not found, treating as drift", "error", err)
 			d.SetId("")
-			return diag.FromErr(fmt.Errorf("resource read failed, cluster not found. Error: %s", err.Error()))
+			return diags
 		}
 		return diag.FromErr(err)
 	}

--- a/rafay/resource_eks_pod_identity.go
+++ b/rafay/resource_eks_pod_identity.go
@@ -322,6 +322,12 @@ func resourceEksPodIdentityRead(ctx context.Context, d *schema.ResourceData, m i
 	}
 	project_id, edge_id, err := getIdFromName(clusterName, projectName)
 	if err != nil {
+		log.Printf("resourceEksPodIdentityRead getIdFromName error %s", err.Error())
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceEksPodIdentityRead: cluster not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 
@@ -340,6 +346,12 @@ func resourceEksPodIdentityRead(ctx context.Context, d *schema.ResourceData, m i
 
 	response, err := auth.AuthAndRequest(uri, "GET", "")
 	if err != nil {
+		log.Printf("resourceEksPodIdentityRead get pod identity error %s", err.Error())
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceEksPodIdentityRead: pod identity not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 

--- a/rafay/resource_fleetplan.go
+++ b/rafay/resource_fleetplan.go
@@ -120,6 +120,12 @@ func resourceFleetPlanRead(ctx context.Context, d *schema.ResourceData, m interf
 	})
 
 	if err != nil {
+		log.Printf("resourceFleetPlanRead get error %s", err.Error())
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceFleetPlanRead: resource not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 

--- a/rafay/resource_gke_cluster.go
+++ b/rafay/resource_gke_cluster.go
@@ -235,6 +235,12 @@ func resourceGKEClusterV3Read(ctx context.Context, d *schema.ResourceData, m int
 		Project: tfClusterState.Metadata.Project,
 	})
 	if err != nil {
+		log.Printf("resourceGKEClusterV3Read get cluster error %s", err.Error())
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceGKEClusterV3Read: cluster not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 

--- a/rafay/resource_organizationalertconfig.go
+++ b/rafay/resource_organizationalertconfig.go
@@ -118,6 +118,11 @@ func resourceOrganizationAlertConfigRead(ctx context.Context, d *schema.Resource
 	})
 	if err != nil {
 		log.Println("read get err")
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceOrganizationAlertConfigRead: resource not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 

--- a/rafay/resource_ztkapolicy.go
+++ b/rafay/resource_ztkapolicy.go
@@ -162,6 +162,11 @@ func resourceZTKAPolicyRead(ctx context.Context, d *schema.ResourceData, m inter
 	})
 	if err != nil {
 		log.Println("read get err")
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceZTKAPolicyRead: resource not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 

--- a/rafay/resource_ztkarule.go
+++ b/rafay/resource_ztkarule.go
@@ -167,6 +167,11 @@ func resourceZTKARuleRead(ctx context.Context, d *schema.ResourceData, m interfa
 	})
 	if err != nil {
 		log.Println("read get err")
+		if IsResourceNotFoundErr(err) {
+			log.Println("resourceZTKARuleRead: resource not found, treating as drift", "error", err)
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
## Summary
- Cherry-pick of #1274 to the `v4.2.x` branch
- Applies the canonical `IsResourceNotFoundErr` pattern to the primary GET in each Read function so out-of-band deletions surface as drift (clear ID + empty diags) instead of hard errors

**Strict drift fixes (17 resources):** `resource_chargeback_share`, `resource_chargeback_group`, `resource_chargeback_group_report`, `resource_chargeback_common_services_policy`, `resource_alertconfig`, `resource_organizationalertconfig`, `resource_breakglassaccess`, `resource_customrole`, `resource_ztkapolicy`, `resource_ztkarule`, `resource_container_registry`, `resource_fleetplan`, `resource_eks_pod_identity`, `resource_aks_cluster_v3`, `resource_gke_cluster`, `resource_cloud_credential`, `resource_access_apikey`

**Partial drift fixes (2 resources):** `resource_eks_cluster`, `resource_aks_cluster`

## Original PR
#1274

🤖 Generated with [Claude Code](https://claude.com/claude-code)