### PR TITLE
RC-47049: suppress no_proxy whitespace diff in AKS v3

### DIFF
--- a/rafay/resource_aks_cluster_v3.go
+++ b/rafay/resource_aks_cluster_v3.go
@@ -29,12 +29,42 @@ import (
 	structpb "google.golang.org/protobuf/types/known/structpb"
 )
 
+// aksV3NoProxyDiff suppresses spurious diffs when no_proxy entries are
+// functionally identical but differ only in whitespace after commas
+// (e.g. "a,b" vs "a, b").
+func aksV3NoProxyDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	normalize := func(v string) string {
+		parts := strings.Split(v, ",")
+		for i, p := range parts {
+			parts[i] = strings.TrimSpace(p)
+		}
+		return strings.Join(parts, ",")
+	}
+	paths := []string{
+		"spec.0.proxy_config.0.no_proxy",
+		"spec.0.proxy.0.no_proxy",
+	}
+	for _, path := range paths {
+		if !d.HasChange(path) {
+			continue
+		}
+		old, newVal := d.GetChange(path)
+		if normalize(old.(string)) == normalize(newVal.(string)) {
+			if err := d.SetNew(path, old); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func resourceAKSClusterV3() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceAKSClusterV3Create,
 		ReadContext:   resourceAKSClusterV3Read,
 		UpdateContext: resourceAKSClusterV3Update,
 		DeleteContext: resourceAKSClusterV3Delete,
+		CustomizeDiff: aksV3NoProxyDiff,
 		Importer: &schema.ResourceImporter{
 			State: resourceAKSClusterV3Import,
 		},


### PR DESCRIPTION
## Summary
- Adds `CustomizeDiff` hook (`aksV3NoProxyDiff`) to `rafay_aks_cluster_v3` resource
- Normalizes `no_proxy` values by trimming spaces around commas before comparing
- Covers both `spec.proxy_config.no_proxy` and `spec.proxy.no_proxy`

## Root Cause
When the user writes `no_proxy = "a, b, c"` (spaces after commas), AKS normalizes it to `"a,b,c"` on return. Terraform sees a perpetual diff between the config and the refreshed state on every subsequent plan.

## Fix
`CustomizeDiff` splits on commas, trims whitespace from each entry, and rejoins before comparing. If normalized forms match, the diff is suppressed.

https://rafaysystems.atlassian.net/browse/RC-47049