### PR TITLE
RC-49702: fix SetNew invalid key error for AKS clusters with proxy_config

### DIFF
--- a/rafay/resource_aks_cluster_v3.go
+++ b/rafay/resource_aks_cluster_v3.go
@@ -28,10 +28,7 @@ import (
 	structpb "google.golang.org/protobuf/types/known/structpb"
 )
 
-// aksV3NoProxyDiff suppresses spurious diffs when no_proxy entries are
-// functionally identical but differ only in whitespace after commas
-// (e.g. "a,b" vs "a, b").
-func aksV3NoProxyDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+func suppressNoProxyDiff(_, old, new string, _ *schema.ResourceData) bool {
 	normalize := func(v string) string {
 		parts := strings.Split(v, ",")
 		for i, p := range parts {
@@ -39,22 +36,35 @@ func aksV3NoProxyDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) 
 		}
 		return strings.Join(parts, ",")
 	}
-	paths := []string{
-		"spec.0.proxy_config.0.no_proxy",
-		"spec.0.proxy.0.no_proxy",
+	return normalize(old) == normalize(new)
+}
+
+// aksV3ClusterSchema injects DiffSuppressFunc onto no_proxy fields so that
+// whitespace-only differences (e.g. "a, b" vs "a,b") are not treated as drift.
+func aksV3ClusterSchema() map[string]*schema.Schema {
+	s := resource.ClusterSchema.Schema
+	spec, ok := s["spec"]
+	if !ok {
+		return s
 	}
-	for _, path := range paths {
-		if !d.HasChange(path) {
+	specResource, ok := spec.Elem.(*schema.Resource)
+	if !ok {
+		return s
+	}
+	for _, blockName := range []string{"proxy_config", "proxy"} {
+		block, ok := specResource.Schema[blockName]
+		if !ok {
 			continue
 		}
-		old, newVal := d.GetChange(path)
-		if normalize(old.(string)) == normalize(newVal.(string)) {
-			if err := d.SetNew(path, old); err != nil {
-				return err
-			}
+		blockResource, ok := block.Elem.(*schema.Resource)
+		if !ok {
+			continue
+		}
+		if noProxy, ok := blockResource.Schema["no_proxy"]; ok {
+			noProxy.DiffSuppressFunc = suppressNoProxyDiff
 		}
 	}
-	return nil
+	return s
 }
 
 func resourceAKSClusterV3() *schema.Resource {
@@ -63,7 +73,6 @@ func resourceAKSClusterV3() *schema.Resource {
 		ReadContext:   resourceAKSClusterV3Read,
 		UpdateContext: resourceAKSClusterV3Update,
 		DeleteContext: resourceAKSClusterV3Delete,
-		CustomizeDiff: aksV3NoProxyDiff,
 		Importer: &schema.ResourceImporter{
 			State: resourceAKSClusterV3Import,
 		},
@@ -75,7 +84,7 @@ func resourceAKSClusterV3() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		Schema:        resource.ClusterSchema.Schema,
+		Schema:        aksV3ClusterSchema(),
 	}
 }
 

--- a/rafay/test_aks_cluster_flatten_test.go
+++ b/rafay/test_aks_cluster_flatten_test.go
@@ -821,3 +821,52 @@ func BenchmarkFlattenAKSManagedCluster(b *testing.B) {
 		flattenAKSManagedCluster(input, p)
 	}
 }
+
+func TestSuppressNoProxyDiff(t *testing.T) {
+	tests := []struct {
+		name     string
+		old      string
+		new      string
+		suppress bool
+	}{
+		{"identical no spaces", "a,b,c", "a,b,c", true},
+		{"spaces after commas", "a,b,c", "a, b, c", true},
+		{"spaces before commas", "a ,b ,c", "a,b,c", true},
+		{"spaces both sides", "a , b , c", "a,b,c", true},
+		{"different values", "a,b,c", "a,b,d", false},
+		{"different length", "a,b", "a,b,c", false},
+		{"empty both", "", "", true},
+		{"empty old", "", "a,b", false},
+		{"empty new", "a,b", "", false},
+		{"single entry with space", "localhost", " localhost ", true},
+		{"real no_proxy with spaces", "10.0.0.0/16, localhost, 127.0.0.1", "10.0.0.0/16,localhost,127.0.0.1", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := suppressNoProxyDiff("", tt.old, tt.new, nil)
+			assert.Equal(t, tt.suppress, got)
+		})
+	}
+}
+
+func TestAksV3ClusterSchemaNoProxyDiffSuppressWired(t *testing.T) {
+	s := aksV3ClusterSchema()
+
+	spec, ok := s["spec"]
+	require.True(t, ok, "spec key missing from schema")
+	specResource, ok := spec.Elem.(*schema.Resource)
+	require.True(t, ok, "spec.Elem is not *schema.Resource")
+
+	for _, blockName := range []string{"proxy_config", "proxy"} {
+		block, ok := specResource.Schema[blockName]
+		if !ok {
+			continue
+		}
+		blockResource, ok := block.Elem.(*schema.Resource)
+		require.True(t, ok, "%s.Elem is not *schema.Resource", blockName)
+
+		noProxy, ok := blockResource.Schema["no_proxy"]
+		require.True(t, ok, "%s.no_proxy field missing", blockName)
+		assert.NotNil(t, noProxy.DiffSuppressFunc, "%s.no_proxy DiffSuppressFunc not set", blockName)
+	}
+}


### PR DESCRIPTION
## Summary
- RC-47049 introduced a `CustomizeDiff` that called `d.SetNew("spec.0.proxy_config.0.no_proxy", ...)` — TF SDK v2 does not support nested list paths in `SetNew`, causing every `terraform plan` on a proxy-configured AKS cluster to fail with `SetNew: invalid key`
- Replaced with `DiffSuppressFunc` on the `no_proxy` schema field, which is the correct SDK mechanism for suppressing whitespace-only diffs
- Added unit tests for the suppress function and schema wiring verification

https://rafaysystems.atlassian.net/browse/RC-49702
