### PR TITLE
RC-51050: fix provider panic on EKS cluster import with systemCompone…

### DIFF
--- a/internal/resource_eks_cluster/eks_cluster_resource_flatten.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_flatten.go
@@ -2231,12 +2231,14 @@ func (v *SystemComponentsPlacementValue) Flatten(ctx context.Context, in *rafay.
 	}
 	v.Tolerations = tolerations
 
-	dsoList := make([]DaemonsetOverrideValue, len(state.DaemonsetOverride.Elements()))
-	d = state.DaemonsetOverride.ElementsAs(ctx, &dsoList, false)
-	diags = append(diags, d...)
 	stDso := DaemonsetOverrideValue{}
-	if len(dsoList) > 0 {
-		stDso = dsoList[0]
+	if !state.DaemonsetOverride.IsNull() && !state.DaemonsetOverride.IsUnknown() && state.DaemonsetOverride.ElementType(ctx) != nil {
+		dsoList := make([]DaemonsetOverrideValue, 0, len(state.DaemonsetOverride.Elements()))
+		d = state.DaemonsetOverride.ElementsAs(ctx, &dsoList, false)
+		diags = append(diags, d...)
+		if len(dsoList) > 0 {
+			stDso = dsoList[0]
+		}
 	}
 
 	// DaemonsetOverride


### PR DESCRIPTION

Reproduces against any EKS cluster whose server-side spec contains
`systemComponentsPlacement` (e.g. only `tolerations` set, no `daemonsetOverride`).

## Root cause

`SpecValue.Flatten` constructs the placement state like this
(`eks_cluster_resource_flatten.go:232`):

```go
stScp := SystemComponentsPlacementValue{}
if !state.SystemComponentsPlacement.IsNull() { ... }



On terraform import the prior state is empty, so the if is skipped and
stScp falls through as the zero-value SystemComponentsPlacementValue{}.
That zero value's DaemonsetOverride is a zero types.ListValue whose
ElementType is nil — distinct from a properly-null types.ListNull(...).

SystemComponentsPlacementValue.Flatten then called
state.DaemonsetOverride.ElementsAs(...) unconditionally. ElementsAs walks
into ToTerraformValue → ElementType().TerraformType(ctx), dereferences
the nil element type, and panics.

The crash only triggers when in.SystemComponentsPlacement != nil, i.e. the
API actually returns a placement block, which is why this only shows up on
import of clusters that have placement configured.

Fix
Guard the ElementsAs call the same way SpecValue.Flatten already guards
its parent list. The guard adds an ElementType(ctx) != nil check so the
zero-ListValue case is also caught (not just IsNull / IsUnknown).