### PR TITLE
RC-51061: EKS: terraform apply blocked after terraform import of rafay_eks_cluster: schema defaults force update to immutable nodegroup fields (volumeIOPS, volumeThroughput)

### DIFF
--- a/internal/provider/eks_cluster_resource.go
+++ b/internal/provider/eks_cluster_resource.go
@@ -708,6 +708,11 @@ func (r *eksClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 		resp.Diagnostics.Append(d...)
 		return
 	}
+	for i := range updatedClusterConfig.ManagedNodeGroups {
+		resource_eks_cluster.StripImmutableManagedNodeGroupFields(
+			updatedClusterConfig.ManagedNodeGroups[i],
+		)
+	}
 	tflog.Debug(ctx, "updated value", map[string]any{"updatedCluster": updatedCluster, "updatedClusterConfig": updatedClusterConfig})
 
 	// Call API to update EKS cluster

--- a/internal/resource_eks_cluster/eks_cluster_resource_expand.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_expand.go
@@ -756,7 +756,9 @@ func (v ClusterConfigValue) Expand(ctx context.Context) (*rafay.EKSClusterConfig
 	if len(vAutoModeConfigList) > 0 {
 		amc, d := vAutoModeConfigList[0].Expand(ctx)
 		diags = append(diags, d...)
-		clusterConfig.AutoModeConfig = amc
+		if amc != nil && (amc.Enabled || amc.NodeRoleARN != "" || len(amc.NodePools) > 0) {
+			clusterConfig.AutoModeConfig = amc
+		}
 	}
 
 	// delete_protection_config block
@@ -2410,7 +2412,7 @@ func (v AutoModeConfigValue) Expand(ctx context.Context) (*rafay.EKSAutoModeConf
 	var amc rafay.EKSAutoModeConfig
 
 	if v.IsNull() {
-		return &rafay.EKSAutoModeConfig{}, diags
+		return nil, diags
 	}
 
 	// Map enabled field
@@ -2435,6 +2437,10 @@ func (v AutoModeConfigValue) Expand(ctx context.Context) (*rafay.EKSAutoModeConf
 		if len(nodePools) > 0 {
 			amc.NodePools = nodePools
 		}
+
+	}
+	if !amc.Enabled && amc.NodeRoleARN == "" && len(amc.NodePools) == 0 {
+		return nil, diags
 	}
 
 	return &amc, diags

--- a/internal/resource_eks_cluster/eks_cluster_resource_expand_managednodegroup.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_expand_managednodegroup.go
@@ -783,21 +783,6 @@ func (v NodeRepairConfig4Value) Expand(ctx context.Context) (*rafay.NodeRepairCo
 	return &nrc, diags
 }
 
-func RestoreImmutableManagedNodeGroupFieldsFromAPI(dst, src *rafay.ManagedNodeGroup) {
-	if dst == nil || src == nil {
-		return
-	}
-	dst.PrivateNetworking = src.PrivateNetworking
-	dst.VolumeIOPS = src.VolumeIOPS
-	dst.VolumeThroughput = src.VolumeThroughput
-	dst.DisableIMDSv1 = src.DisableIMDSv1
-	dst.DisablePodIMDS = src.DisablePodIMDS
-	dst.EFAEnabled = src.EFAEnabled
-	dst.EBSOptimized = src.EBSOptimized
-	dst.VolumeEncrypted = src.VolumeEncrypted
-	dst.MaxPodsPerNode = src.MaxPodsPerNode
-	dst.Spot = src.Spot
-}
 func StripImmutableManagedNodeGroupFields(mng *rafay.ManagedNodeGroup) {
 	if mng == nil {
 		return

--- a/internal/resource_eks_cluster/eks_cluster_resource_expand_managednodegroup.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_expand_managednodegroup.go
@@ -782,3 +782,34 @@ func (v NodeRepairConfig4Value) Expand(ctx context.Context) (*rafay.NodeRepairCo
 
 	return &nrc, diags
 }
+
+func RestoreImmutableManagedNodeGroupFieldsFromAPI(dst, src *rafay.ManagedNodeGroup) {
+	if dst == nil || src == nil {
+		return
+	}
+	dst.PrivateNetworking = src.PrivateNetworking
+	dst.VolumeIOPS = src.VolumeIOPS
+	dst.VolumeThroughput = src.VolumeThroughput
+	dst.DisableIMDSv1 = src.DisableIMDSv1
+	dst.DisablePodIMDS = src.DisablePodIMDS
+	dst.EFAEnabled = src.EFAEnabled
+	dst.EBSOptimized = src.EBSOptimized
+	dst.VolumeEncrypted = src.VolumeEncrypted
+	dst.MaxPodsPerNode = src.MaxPodsPerNode
+	dst.Spot = src.Spot
+}
+func StripImmutableManagedNodeGroupFields(mng *rafay.ManagedNodeGroup) {
+	if mng == nil {
+		return
+	}
+	mng.PrivateNetworking = nil
+	mng.VolumeIOPS = nil
+	mng.VolumeThroughput = nil
+	mng.DisableIMDSv1 = nil
+	mng.DisablePodIMDS = nil
+	mng.EFAEnabled = nil
+	mng.EBSOptimized = nil
+	mng.VolumeEncrypted = nil
+	mng.MaxPodsPerNode = nil
+	mng.Spot = nil
+}

--- a/internal/resource_eks_cluster/eks_cluster_resource_flatten.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_flatten.go
@@ -694,14 +694,15 @@ func (v *ClusterConfigValue) Flatten(ctx context.Context, in rafay.EKSClusterCon
 		v.AddonsConfig = types.ListNull(AddonsConfigValue{}.Type(ctx))
 	}
 
-	if in.AutoModeConfig != nil {
+	if in.AutoModeConfig != nil && (in.AutoModeConfig.Enabled || in.AutoModeConfig.NodeRoleARN != "" || len(in.AutoModeConfig.NodePools) > 0) {
 		autoModeConfig := NewAutoModeConfigValueNull()
 		d = autoModeConfig.Flatten(ctx, in.AutoModeConfig)
 		diags = append(diags, d...)
 		v.AutoModeConfig, d = types.ListValue(AutoModeConfigValue{}.Type(ctx), []attr.Value{autoModeConfig})
 		diags = append(diags, d...)
 	} else {
-		v.AutoModeConfig = types.ListNull(AutoModeConfigValue{}.Type(ctx))
+		v.AutoModeConfig, d = types.ListValue(AutoModeConfigValue{}.Type(ctx), []attr.Value{})
+		diags = append(diags, d...)
 	}
 
 	if in.DeleteProtection != nil {

--- a/internal/resource_eks_cluster/eks_cluster_resource_gen.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_gen.go
@@ -409,38 +409,28 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"disable_imdsv1": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Whether to disable IMDSv1 on the node group.",
 										MarkdownDescription: "Whether to disable IMDSv1 on the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"disable_pods_imds": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Whether to disable IMDS for pods in the node group.",
 										MarkdownDescription: "Whether to disable IMDS for pods in the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"ebs_optimized": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "enables EBS optimization.",
 										MarkdownDescription: "enables EBS optimization.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"efa_enabled": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Creates the maximum allowed number of EFA-enabled network cards on nodes in this group.",
 										MarkdownDescription: "Creates the maximum allowed number of EFA-enabled network cards on nodes in this group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"enable_detailed_monitoring": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Enable EC2 detailed monitoring",
 										MarkdownDescription: "Enable EC2 detailed monitoring",
-										Default:             booldefault.StaticBool(false),
 									},
 									"iam": schema.SingleNestedAttribute{
 										Attributes: map[string]schema.Attribute{
@@ -714,8 +704,6 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"max_pods_per_node": schema.Int64Attribute{
 										Optional: true,
-										Computed: true,
-										Default:  int64default.StaticInt64(0),
 									},
 									"max_size": schema.Int64Attribute{
 										Optional: true,
@@ -822,10 +810,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"private_networking": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Enable private networking for the node group.",
 										MarkdownDescription: "Enable private networking for the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"security_groups": schema.SingleNestedAttribute{
 										Attributes: map[string]schema.Attribute{
@@ -855,10 +841,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"spot": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Whether to use spot instances for the node group.",
 										MarkdownDescription: "Whether to use spot instances for the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"ssh": schema.SingleNestedAttribute{
 										Attributes: map[string]schema.Attribute{
@@ -962,17 +946,13 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"volume_encrypted": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "whether to encrypt volumes attached to instances in the nodegroup.",
 										MarkdownDescription: "whether to encrypt volumes attached to instances in the nodegroup.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"volume_iops": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
 										MarkdownDescription: "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
-										Default:             int64default.StaticInt64(3000),
 									},
 									"volume_kms_key_id": schema.StringAttribute{
 										Optional:            true,
@@ -993,10 +973,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"volume_throughput": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
 										MarkdownDescription: "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
-										Default:             int64default.StaticInt64(125),
 									},
 									"volume_type": schema.StringAttribute{
 										Optional:            true,
@@ -1103,38 +1081,28 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"disable_imdsv1": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Whether to disable IMDSv1 on the node group.",
 										MarkdownDescription: "Whether to disable IMDSv1 on the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"disable_pods_imds": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Whether to disable IMDS for pods in the node group.",
 										MarkdownDescription: "Whether to disable IMDS for pods in the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"ebs_optimized": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "enables EBS optimization.",
 										MarkdownDescription: "enables EBS optimization.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"efa_enabled": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Creates the maximum allowed number of EFA-enabled network cards on nodes in this group.",
 										MarkdownDescription: "Creates the maximum allowed number of EFA-enabled network cards on nodes in this group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"enable_detailed_monitoring": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Enable EC2 detailed monitoring",
 										MarkdownDescription: "Enable EC2 detailed monitoring",
-										Default:             booldefault.StaticBool(false),
 									},
 									"iam": schema.SingleNestedAttribute{
 										Attributes: map[string]schema.Attribute{
@@ -1475,8 +1443,6 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"max_pods_per_node": schema.Int64Attribute{
 										Optional: true,
-										Computed: true,
-										Default:  int64default.StaticInt64(0),
 									},
 									"max_size": schema.Int64Attribute{
 										Optional: true,
@@ -1516,10 +1482,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"private_networking": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Enable private networking for the node group.",
 										MarkdownDescription: "Enable private networking for the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"security_groups": schema.SingleNestedAttribute{
 										Attributes: map[string]schema.Attribute{
@@ -1664,17 +1628,13 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"volume_encrypted": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "whether to encrypt volumes attached to instances in the nodegroup.",
 										MarkdownDescription: "whether to encrypt volumes attached to instances in the nodegroup.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"volume_iops": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
 										MarkdownDescription: "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
-										Default:             int64default.StaticInt64(3000),
 									},
 									"volume_kms_key_id": schema.StringAttribute{
 										Optional:            true,
@@ -1695,10 +1655,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"volume_throughput": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
 										MarkdownDescription: "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
-										Default:             int64default.StaticInt64(125),
 									},
 									"volume_type": schema.StringAttribute{
 										Optional:            true,
@@ -2542,10 +2500,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 												},
 												"role_only": schema.BoolAttribute{
 													Optional:            true,
-													Computed:            true,
 													Description:         "Specify if only the IAM Service Account role should be created without creating/annotating the service account.",
 													MarkdownDescription: "Specify if only the IAM Service Account role should be created without creating/annotating the service account.",
-													Default:             booldefault.StaticBool(false),
 												},
 												"tags": schema.MapAttribute{
 													ElementType:         types.StringType,
@@ -2799,38 +2755,28 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"disable_imdsv1": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Whether to disable IMDSv1 on the node group.",
 										MarkdownDescription: "Whether to disable IMDSv1 on the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"disable_pods_imds": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Whether to disable IMDS for pods in the node group.",
 										MarkdownDescription: "Whether to disable IMDS for pods in the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"ebs_optimized": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "enables EBS optimization.",
 										MarkdownDescription: "enables EBS optimization.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"efa_enabled": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Creates the maximum allowed number of EFA-enabled network cards on nodes in this group.",
 										MarkdownDescription: "Creates the maximum allowed number of EFA-enabled network cards on nodes in this group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"enable_detailed_monitoring": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Enable EC2 detailed monitoring",
 										MarkdownDescription: "Enable EC2 detailed monitoring",
-										Default:             booldefault.StaticBool(false),
 									},
 									"instance_name": schema.StringAttribute{
 										Optional:            true,
@@ -2861,8 +2807,6 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"max_pods_per_node": schema.Int64Attribute{
 										Optional: true,
-										Computed: true,
-										Default:  int64default.StaticInt64(0),
 									},
 									"max_size": schema.Int64Attribute{
 										Optional: true,
@@ -2892,17 +2836,13 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"private_networking": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Enable private networking for the node group.",
 										MarkdownDescription: "Enable private networking for the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"spot": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Whether to use spot instances for the node group.",
 										MarkdownDescription: "Whether to use spot instances for the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"subnets": schema.SetAttribute{
 										ElementType:         types.StringType,
@@ -2923,17 +2863,13 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"volume_encrypted": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "whether to encrypt volumes attached to instances in the nodegroup.",
 										MarkdownDescription: "whether to encrypt volumes attached to instances in the nodegroup.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"volume_iops": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
 										MarkdownDescription: "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
-										Default:             int64default.StaticInt64(3000),
 									},
 									"volume_kms_key_id": schema.StringAttribute{
 										Optional:            true,
@@ -2954,10 +2890,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"volume_throughput": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
 										MarkdownDescription: "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
-										Default:             int64default.StaticInt64(125),
 									},
 									"volume_type": schema.StringAttribute{
 										Optional:            true,
@@ -3112,18 +3046,12 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 														Attributes: map[string]schema.Attribute{
 															"alb_ingress": schema.BoolAttribute{
 																Optional: true,
-																Computed: true,
-																Default:  booldefault.StaticBool(false),
 															},
 															"app_mesh": schema.BoolAttribute{
 																Optional: true,
-																Computed: true,
-																Default:  booldefault.StaticBool(false),
 															},
 															"app_mesh_review": schema.BoolAttribute{
 																Optional: true,
-																Computed: true,
-																Default:  booldefault.StaticBool(false),
 															},
 															"auto_scaler": schema.BoolAttribute{
 																Optional: true,
@@ -3132,33 +3060,21 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 															},
 															"cert_manager": schema.BoolAttribute{
 																Optional: true,
-																Computed: true,
-																Default:  booldefault.StaticBool(false),
 															},
 															"cloud_watch": schema.BoolAttribute{
 																Optional: true,
-																Computed: true,
-																Default:  booldefault.StaticBool(false),
 															},
 															"ebs": schema.BoolAttribute{
 																Optional: true,
-																Computed: true,
-																Default:  booldefault.StaticBool(false),
 															},
 															"efs": schema.BoolAttribute{
 																Optional: true,
-																Computed: true,
-																Default:  booldefault.StaticBool(false),
 															},
 															"external_dns": schema.BoolAttribute{
 																Optional: true,
-																Computed: true,
-																Default:  booldefault.StaticBool(false),
 															},
 															"fsx": schema.BoolAttribute{
 																Optional: true,
-																Computed: true,
-																Default:  booldefault.StaticBool(false),
 															},
 															"image_builder": schema.BoolAttribute{
 																Optional: true,
@@ -3167,8 +3083,6 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 															},
 															"xray": schema.BoolAttribute{
 																Optional: true,
-																Computed: true,
-																Default:  booldefault.StaticBool(false),
 															},
 														},
 														CustomType: IamNodeGroupWithAddonPolicies4Type{
@@ -3528,38 +3442,28 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"disable_imdsv1": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Whether to disable IMDSv1 on the node group.",
 										MarkdownDescription: "Whether to disable IMDSv1 on the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"disable_pods_imds": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Whether to disable IMDS for pods in the node group.",
 										MarkdownDescription: "Whether to disable IMDS for pods in the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"ebs_optimized": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "enables EBS optimization.",
 										MarkdownDescription: "enables EBS optimization.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"efa_enabled": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Creates the maximum allowed number of EFA-enabled network cards on nodes in this group.",
 										MarkdownDescription: "Creates the maximum allowed number of EFA-enabled network cards on nodes in this group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"enable_detailed_monitoring": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Enable EC2 detailed monitoring",
 										MarkdownDescription: "Enable EC2 detailed monitoring",
-										Default:             booldefault.StaticBool(false),
 									},
 									"instance_name": schema.StringAttribute{
 										Optional:            true,
@@ -3584,8 +3488,6 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"max_pods_per_node": schema.Int64Attribute{
 										Optional: true,
-										Computed: true,
-										Default:  int64default.StaticInt64(0),
 									},
 									"max_size": schema.Int64Attribute{
 										Optional: true,
@@ -3615,10 +3517,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"private_networking": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Enable private networking for the node group.",
 										MarkdownDescription: "Enable private networking for the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"subnet_cidr": schema.StringAttribute{
 										Optional:            true,
@@ -3650,17 +3550,13 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"volume_encrypted": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "whether to encrypt volumes attached to instances in the nodegroup.",
 										MarkdownDescription: "whether to encrypt volumes attached to instances in the nodegroup.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"volume_iops": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
 										MarkdownDescription: "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
-										Default:             int64default.StaticInt64(3000),
 									},
 									"volume_kms_key_id": schema.StringAttribute{
 										Optional:            true,
@@ -3681,10 +3577,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"volume_throughput": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
 										MarkdownDescription: "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
-										Default:             int64default.StaticInt64(125),
 									},
 									"volume_type": schema.StringAttribute{
 										Optional:            true,
@@ -4260,10 +4154,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"auto_allocate_ipv6": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "AutoAllocateIPV6 requests an IPv6 CIDR block with /56 prefix for the VPC.",
 										MarkdownDescription: "AutoAllocateIPV6 requests an IPv6 CIDR block with /56 prefix for the VPC.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"cidr": schema.StringAttribute{
 										Optional:            true,

--- a/internal/resource_eks_cluster/eks_cluster_resource_spec.json
+++ b/internal/resource_eks_cluster/eks_cluster_resource_spec.json
@@ -466,10 +466,8 @@
                                                     "name": "enable_detailed_monitoring",
                                                     "bool": {
                                                         "description": "Enable EC2 detailed monitoring",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                     
                                                     }
                                                 },
                                                 {
@@ -512,10 +510,8 @@
                                                 {
                                                     "name": "max_pods_per_node",
                                                     "int64": {
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 0
-                                                        } 
+                                                        "computed_optional_required": "optional"
+                                                       
                                                     }
                                                 },
                                                 
@@ -523,50 +519,40 @@
                                                     "name": "disable_imdsv1",
                                                     "bool": {
                                                         "description": "Whether to disable IMDSv1 on the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                       
                                                     }
                                                 },
                                                 {
                                                     "name": "disable_pods_imds",
                                                     "bool": {
                                                         "description": "Whether to disable IMDS for pods in the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                       
                                                     }
                                                 },
                                                 {
                                                     "name": "efa_enabled",
                                                     "bool": {
                                                         "description": "Creates the maximum allowed number of EFA-enabled network cards on nodes in this group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                       
                                                     }
                                                 },
                                                 {
                                                     "name": "private_networking",
                                                     "bool": {
                                                         "description": "Enable private networking for the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                        
                                                     }
                                                 },
                                                 {
                                                     "name": "volume_iops",
                                                     "int64": {
                                                         "description": "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 3000
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                        
                                                     }
                                                 },
                                                 {
@@ -583,10 +569,8 @@
                                                     "name": "volume_throughput",
                                                     "int64": {
                                                         "description": "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 125
-                                                        }
+                                                        "computed_optional_required": "optional"
+        
                                                     }
                                                 },
                                                 {
@@ -674,10 +658,8 @@
                                                     "name": "ebs_optimized",
                                                     "bool": {
                                                         "description": "enables EBS optimization.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                      
                                                     }
                                                 },
                                                 {
@@ -691,10 +673,8 @@
                                                     "name": "volume_encrypted",
                                                     "bool": {
                                                         "description": "whether to encrypt volumes attached to instances in the nodegroup.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                       
                                                     }
                                                 },
                                                 {
@@ -1383,10 +1363,8 @@
                                                     "name": "enable_detailed_monitoring",
                                                     "bool": {
                                                         "description": "Enable EC2 detailed monitoring",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                     
                                                     }
                                                 },
                                                 {
@@ -1431,10 +1409,8 @@
                                                 {
                                                     "name": "max_pods_per_node",
                                                     "int64": {
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 0
-                                                        }    
+                                                        "computed_optional_required": "optional"
+                                                         
                                                     }
                                                 },
                                                 
@@ -1442,50 +1418,40 @@
                                                     "name": "disable_imdsv1",
                                                     "bool": {
                                                         "description": "Whether to disable IMDSv1 on the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                       
                                                     }
                                                 },
                                                 {
                                                     "name": "disable_pods_imds",
                                                     "bool": {
                                                         "description": "Whether to disable IMDS for pods in the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                       
                                                     }
                                                 },
                                                 {
                                                     "name": "efa_enabled",
                                                     "bool": {
                                                         "description": "Creates the maximum allowed number of EFA-enabled network cards on nodes in this group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                       
                                                     }
                                                 },
                                                 {
                                                     "name": "private_networking",
                                                     "bool": {
                                                         "description": "Enable private networking for the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                    
                                                     }
                                                 },
                                                 {
                                                     "name": "volume_iops",
                                                     "int64": {
                                                         "description": "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 3000
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                      
                                                     }
                                                 },
                                                 {
@@ -1502,10 +1468,8 @@
                                                     "name": "volume_throughput",
                                                     "int64": {
                                                         "description": "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 125
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                      
                                                     }
                                                 },
                                                 {
@@ -1593,10 +1557,8 @@
                                                     "name": "ebs_optimized",
                                                     "bool": {
                                                         "description": "enables EBS optimization.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                        
                                                     }
                                                 },
                                                 {
@@ -1610,10 +1572,8 @@
                                                     "name": "volume_encrypted",
                                                     "bool": {
                                                         "description": "whether to encrypt volumes attached to instances in the nodegroup.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                      
                                                     }
                                                 },
                                                 {
@@ -1654,10 +1614,8 @@
                                                     "name": "spot",
                                                     "bool": {
                                                         "description": "Whether to use spot instances for the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                       
                                                     }
                                                 },
                                                 {
@@ -2363,10 +2321,8 @@
                                                     "name": "enable_detailed_monitoring",
                                                     "bool": {
                                                         "description": "Enable EC2 detailed monitoring",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                      
                                                     }
                                                 },
                                                 {
@@ -2416,10 +2372,8 @@
                                                 {
                                                     "name": "max_pods_per_node",
                                                     "int64": {
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 0
-                                                        } 
+                                                        "computed_optional_required": "optional"
+                                                      
                                                     }
                                                 },
                                                 
@@ -2427,50 +2381,40 @@
                                                     "name": "disable_imdsv1",
                                                     "bool": {
                                                         "description": "Whether to disable IMDSv1 on the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                       
                                                     }
                                                 },
                                                 {
                                                     "name": "disable_pods_imds",
                                                     "bool": {
                                                         "description": "Whether to disable IMDS for pods in the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                    
                                                     }
                                                 },
                                                 {
                                                     "name": "efa_enabled",
                                                     "bool": {
                                                         "description": "Creates the maximum allowed number of EFA-enabled network cards on nodes in this group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                        
                                                     }
                                                 },
                                                 {
                                                     "name": "private_networking",
                                                     "bool": {
                                                         "description": "Enable private networking for the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                       
                                                     }
                                                 },
                                                 {
                                                     "name": "volume_iops",
                                                     "int64": {
                                                         "description": "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 3000
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                      
                                                     }
                                                 },
                                                 {
@@ -2487,10 +2431,8 @@
                                                     "name": "volume_throughput",
                                                     "int64": {
                                                         "description": "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 125
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                      
                                                     }
                                                 },
                                                 {
@@ -2579,10 +2521,8 @@
                                                     "name": "ebs_optimized",
                                                     "bool": {
                                                         "description": "enables EBS optimization.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                       
                                                     }
                                                 },
                                                 {
@@ -2596,10 +2536,8 @@
                                                     "name": "volume_encrypted",
                                                     "bool": {
                                                         "description": "whether to encrypt volumes attached to instances in the nodegroup.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                        
                                                     }
                                                 },
                                                 {
@@ -3579,10 +3517,8 @@
                                                                     "name": "role_only",
                                                                     "bool": {
                                                                         "description": "Specify if only the IAM Service Account role should be created without creating/annotating the service account.",
-                                                                        "computed_optional_required": "computed_optional",
-                                                                        "default": {
-                                                                            "static": false
-                                                                        }
+                                                                        "computed_optional_required": "optional"
+                                                                       
                                                                     }
                                                                 },
                                                                 {
@@ -3839,10 +3775,8 @@
                                                     "name": "auto_allocate_ipv6",
                                                     "bool": {
                                                         "description": "AutoAllocateIPV6 requests an IPv6 CIDR block with /56 prefix for the VPC.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                        
                                                     }
                                                 },
                                                 {
@@ -4527,91 +4461,71 @@
                                                                         {
                                                                             "name": "alb_ingress",
                                                                             "bool": {
-                                                                                "computed_optional_required": "computed_optional",
-                                                                                "default": {
-                                                                                    "static": false
-                                                                                }
+                                                                                "computed_optional_required": "optional"
+                                                                               
                                                                             }
                                                                         },
                                                                         {
                                                                             "name": "app_mesh",
                                                                             "bool": {
-                                                                                "computed_optional_required": "computed_optional",
-                                                                                "default": {
-                                                                                    "static": false
-                                                                                }
+                                                                                "computed_optional_required": "optional"
+                                                                               
                                                                             }
                                                                         },
                                                                         {
                                                                             "name": "app_mesh_review",
                                                                             "bool": {
-                                                                                "computed_optional_required": "computed_optional",
-                                                                                "default": {
-                                                                                    "static": false
-                                                                                }
+                                                                                "computed_optional_required": "optional"
+                                                                               
                                                                             }
                                                                         },
                                                                         {
                                                                             "name": "cert_manager",
                                                                             "bool": {
-                                                                                "computed_optional_required": "computed_optional",
-                                                                                "default": {
-                                                                                    "static": false
-                                                                                }
+                                                                                "computed_optional_required": "optional"
+                                                                                
                                                                             }
                                                                         },
                                                                         {
                                                                             "name": "cloud_watch",
                                                                             "bool": {
-                                                                                "computed_optional_required": "computed_optional",
-                                                                                "default": {
-                                                                                    "static": false
-                                                                                }
+                                                                                "computed_optional_required": "optional"
+                                                                               
                                                                             }
                                                                         },
                                                                         {
                                                                             "name": "ebs",
                                                                             "bool": {
-                                                                                "computed_optional_required": "computed_optional",
-                                                                                "default": {
-                                                                                    "static": false
-                                                                                }
+                                                                                "computed_optional_required": "optional"
+                                                                               
                                                                             }
                                                                         },
                                                                         {
                                                                             "name": "efs",
                                                                             "bool": {
-                                                                                "computed_optional_required": "computed_optional",
-                                                                                "default": {
-                                                                                    "static": false
-                                                                                }
+                                                                                "computed_optional_required": "optional"
+                                                                               
                                                                             }
                                                                         },
                                                                         {
                                                                             "name": "external_dns",
                                                                             "bool": {
-                                                                                "computed_optional_required": "computed_optional",
-                                                                                "default": {
-                                                                                    "static": false
-                                                                                }
+                                                                                "computed_optional_required": "optional"
+                                                                               
                                                                             }
                                                                         },
                                                                         {
                                                                             "name": "fsx",
                                                                             "bool": {
-                                                                                "computed_optional_required": "computed_optional",
-                                                                                "default": {
-                                                                                    "static": false
-                                                                                }
+                                                                                "computed_optional_required": "optional"
+                                                                            
                                                                             }
                                                                         },
                                                                         {
                                                                             "name": "xray",
                                                                             "bool": {
-                                                                                "computed_optional_required": "computed_optional",
-                                                                                "default": {
-                                                                                    "static": false
-                                                                                }
+                                                                                "computed_optional_required": "optional"
+                                                                               
                                                                             }
                                                                         },
                                                                         {
@@ -5085,11 +4999,9 @@
                                                 {
                                                     "name": "enable_detailed_monitoring",
                                                     "bool": {
-                                                        "computed_optional_required": "computed_optional",
-                                                        "description": "Enable EC2 detailed monitoring",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional",
+                                                        "description": "Enable EC2 detailed monitoring"
+                                                       
                                                     }
                                                 },
                                                 {
@@ -5141,60 +5053,48 @@
                                                 {
                                                     "name": "max_pods_per_node",
                                                     "int64": {
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 0
-                                                        }   
+                                                        "computed_optional_required": "optional"
+                                                        
                                                     }
                                                 },
                                                 {
                                                     "name": "disable_imdsv1",
                                                     "bool": {
                                                         "description": "Whether to disable IMDSv1 on the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                       
                                                     }
                                                 },
                                                 {
                                                     "name": "disable_pods_imds",
                                                     "bool": {
                                                         "description": "Whether to disable IMDS for pods in the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                       
                                                     }
                                                 },
                                                 {
                                                     "name": "efa_enabled",
                                                     "bool": {
                                                         "description": "Creates the maximum allowed number of EFA-enabled network cards on nodes in this group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                       
                                                     }
                                                 },
                                                 {
                                                     "name": "private_networking",
                                                     "bool": {
                                                         "description": "Enable private networking for the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                        
                                                     }
                                                 },
                                                 {
                                                     "name": "volume_iops",
                                                     "int64": {
                                                         "description": "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 3000
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                    
                                                     }
                                                 },
                                                 {
@@ -5211,10 +5111,8 @@
                                                     "name": "volume_throughput",
                                                     "int64": {
                                                         "description": "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 125
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                      
                                                     }
                                                 },
                                                 {
@@ -5302,10 +5200,8 @@
                                                     "name": "ebs_optimized",
                                                     "bool": {
                                                         "description": "enables EBS optimization.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                       
                                                     }
                                                 },
                                                 {
@@ -5319,10 +5215,8 @@
                                                     "name": "volume_encrypted",
                                                     "bool": {
                                                         "description": "whether to encrypt volumes attached to instances in the nodegroup.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                       
                                                     }
                                                 },
                                                 {
@@ -5363,10 +5257,8 @@
                                                     "name": "spot",
                                                     "bool": {
                                                         "description": "Whether to use spot instances for the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
+                                                        
                                                     }
                                                 }
                                             ]

--- a/internal/resource_mks_cluster/mks_cluster_resource_gen.go
+++ b/internal/resource_mks_cluster/mks_cluster_resource_gen.go
@@ -227,29 +227,6 @@ func MksClusterResourceSchema(ctx context.Context) schema.Schema {
 								Description:         "MKS Cluster control plane overrides",
 								MarkdownDescription: "MKS Cluster control plane overrides",
 							},
-							"oidc_configuration": schema.SingleNestedAttribute{
-								Attributes: map[string]schema.Attribute{
-									"api_audiences": schema.SetAttribute{
-										ElementType:         types.StringType,
-										Optional:            true,
-										Description:         "API audiences for OIDC",
-										MarkdownDescription: "API audiences for OIDC",
-									},
-									"service_account_issuer": schema.StringAttribute{
-										Optional:            true,
-										Description:         "Service account issuer URL for OIDC",
-										MarkdownDescription: "Service account issuer URL for OIDC",
-									},
-								},
-								CustomType: OidcConfigurationType{
-									ObjectType: types.ObjectType{
-										AttrTypes: OidcConfigurationValue{}.AttributeTypes(ctx),
-									},
-								},
-								Optional:            true,
-								Description:         "OIDC configuration for MKS cluster",
-								MarkdownDescription: "OIDC configuration for MKS cluster",
-							},
 							"dedicated_control_plane": schema.BoolAttribute{
 								Optional:            true,
 								Description:         "Select this option for preventing scheduling of user workloads on Control Plane nodes",
@@ -509,6 +486,29 @@ func MksClusterResourceSchema(ctx context.Context) schema.Schema {
 								Required:            true,
 								Description:         "holds node configuration for the cluster",
 								MarkdownDescription: "holds node configuration for the cluster",
+							},
+							"oidc_configuration": schema.SingleNestedAttribute{
+								Attributes: map[string]schema.Attribute{
+									"api_audiences": schema.SetAttribute{
+										ElementType:         types.StringType,
+										Optional:            true,
+										Description:         "API audiences for OIDC",
+										MarkdownDescription: "API audiences for OIDC",
+									},
+									"service_account_issuer": schema.StringAttribute{
+										Optional:            true,
+										Description:         "Service account issuer URL for OIDC",
+										MarkdownDescription: "Service account issuer URL for OIDC",
+									},
+								},
+								CustomType: OidcConfigurationType{
+									ObjectType: types.ObjectType{
+										AttrTypes: OidcConfigurationValue{}.AttributeTypes(ctx),
+									},
+								},
+								Optional:            true,
+								Description:         "OIDC configuration for MKS cluster",
+								MarkdownDescription: "OIDC configuration for MKS cluster",
 							},
 							"platform_version": schema.StringAttribute{
 								Optional:            true,
@@ -3535,18 +3535,6 @@ func (v ConfigValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 		)
 	}
 
-	var kubeletExtraArgsVal basetypes.MapValue
-	switch {
-	case v.KubeletExtraArgs.IsUnknown():
-		kubeletExtraArgsVal = types.MapUnknown(types.StringType)
-	case v.KubeletExtraArgs.IsNull():
-		kubeletExtraArgsVal = types.MapNull(types.StringType)
-	default:
-		var d diag.Diagnostics
-		kubeletExtraArgsVal, d = types.MapValue(types.StringType, v.KubeletExtraArgs.Elements())
-		diags.Append(d...)
-	}
-
 	var oidcConfiguration basetypes.ObjectValue
 
 	if v.OidcConfiguration.IsNull() {
@@ -3566,6 +3554,18 @@ func (v ConfigValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, 
 			OidcConfigurationValue{}.AttributeTypes(ctx),
 			v.OidcConfiguration.Attributes(),
 		)
+	}
+
+	var kubeletExtraArgsVal basetypes.MapValue
+	switch {
+	case v.KubeletExtraArgs.IsUnknown():
+		kubeletExtraArgsVal = types.MapUnknown(types.StringType)
+	case v.KubeletExtraArgs.IsNull():
+		kubeletExtraArgsVal = types.MapNull(types.StringType)
+	default:
+		var d diag.Diagnostics
+		kubeletExtraArgsVal, d = types.MapValue(types.StringType, v.KubeletExtraArgs.Elements())
+		diags.Append(d...)
 	}
 
 	if diags.HasError() {
@@ -10363,6 +10363,412 @@ func (v TaintsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	}
 }
 
+var _ basetypes.ObjectTypable = OidcConfigurationType{}
+
+type OidcConfigurationType struct {
+	basetypes.ObjectType
+}
+
+func (t OidcConfigurationType) Equal(o attr.Type) bool {
+	other, ok := o.(OidcConfigurationType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t OidcConfigurationType) String() string {
+	return "OidcConfigurationType"
+}
+
+func (t OidcConfigurationType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	apiAudiencesAttribute, ok := attributes["api_audiences"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`api_audiences is missing from object`)
+
+		return nil, diags
+	}
+
+	apiAudiencesVal, ok := apiAudiencesAttribute.(basetypes.SetValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`api_audiences expected to be basetypes.SetValue, was: %T`, apiAudiencesAttribute))
+	}
+
+	serviceAccountIssuerAttribute, ok := attributes["service_account_issuer"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`service_account_issuer is missing from object`)
+
+		return nil, diags
+	}
+
+	serviceAccountIssuerVal, ok := serviceAccountIssuerAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`service_account_issuer expected to be basetypes.StringValue, was: %T`, serviceAccountIssuerAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return OidcConfigurationValue{
+		ApiAudiences:         apiAudiencesVal,
+		ServiceAccountIssuer: serviceAccountIssuerVal,
+		state:                attr.ValueStateKnown,
+	}, diags
+}
+
+func NewOidcConfigurationValueNull() OidcConfigurationValue {
+	return OidcConfigurationValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewOidcConfigurationValueUnknown() OidcConfigurationValue {
+	return OidcConfigurationValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewOidcConfigurationValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (OidcConfigurationValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing OidcConfigurationValue Attribute Value",
+				"While creating a OidcConfigurationValue value, a missing attribute value was detected. "+
+					"A OidcConfigurationValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("OidcConfigurationValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid OidcConfigurationValue Attribute Type",
+				"While creating a OidcConfigurationValue value, an invalid attribute value was detected. "+
+					"A OidcConfigurationValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("OidcConfigurationValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("OidcConfigurationValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra OidcConfigurationValue Attribute Value",
+				"While creating a OidcConfigurationValue value, an extra attribute value was detected. "+
+					"A OidcConfigurationValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra OidcConfigurationValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewOidcConfigurationValueUnknown(), diags
+	}
+
+	apiAudiencesAttribute, ok := attributes["api_audiences"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`api_audiences is missing from object`)
+
+		return NewOidcConfigurationValueUnknown(), diags
+	}
+
+	apiAudiencesVal, ok := apiAudiencesAttribute.(basetypes.SetValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`api_audiences expected to be basetypes.SetValue, was: %T`, apiAudiencesAttribute))
+	}
+
+	serviceAccountIssuerAttribute, ok := attributes["service_account_issuer"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`service_account_issuer is missing from object`)
+
+		return NewOidcConfigurationValueUnknown(), diags
+	}
+
+	serviceAccountIssuerVal, ok := serviceAccountIssuerAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`service_account_issuer expected to be basetypes.StringValue, was: %T`, serviceAccountIssuerAttribute))
+	}
+
+	if diags.HasError() {
+		return NewOidcConfigurationValueUnknown(), diags
+	}
+
+	return OidcConfigurationValue{
+		ApiAudiences:         apiAudiencesVal,
+		ServiceAccountIssuer: serviceAccountIssuerVal,
+		state:                attr.ValueStateKnown,
+	}, diags
+}
+
+func NewOidcConfigurationValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) OidcConfigurationValue {
+	object, diags := NewOidcConfigurationValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewOidcConfigurationValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t OidcConfigurationType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewOidcConfigurationValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewOidcConfigurationValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewOidcConfigurationValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewOidcConfigurationValueMust(OidcConfigurationValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t OidcConfigurationType) ValueType(ctx context.Context) attr.Value {
+	return OidcConfigurationValue{}
+}
+
+var _ basetypes.ObjectValuable = OidcConfigurationValue{}
+
+type OidcConfigurationValue struct {
+	ApiAudiences         basetypes.SetValue    `tfsdk:"api_audiences"`
+	ServiceAccountIssuer basetypes.StringValue `tfsdk:"service_account_issuer"`
+	state                attr.ValueState
+}
+
+func (v OidcConfigurationValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["api_audiences"] = basetypes.SetType{
+		ElemType: types.StringType,
+	}.TerraformType(ctx)
+	attrTypes["service_account_issuer"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.ApiAudiences.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["api_audiences"] = val
+
+		val, err = v.ServiceAccountIssuer.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["service_account_issuer"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v OidcConfigurationValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v OidcConfigurationValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v OidcConfigurationValue) String() string {
+	return "OidcConfigurationValue"
+}
+
+func (v OidcConfigurationValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var apiAudiencesVal basetypes.SetValue
+	switch {
+	case v.ApiAudiences.IsUnknown():
+		apiAudiencesVal = types.SetUnknown(types.StringType)
+	case v.ApiAudiences.IsNull():
+		apiAudiencesVal = types.SetNull(types.StringType)
+	default:
+		var d diag.Diagnostics
+		apiAudiencesVal, d = types.SetValue(types.StringType, v.ApiAudiences.Elements())
+		diags.Append(d...)
+	}
+
+	if diags.HasError() {
+		return types.ObjectUnknown(map[string]attr.Type{
+			"api_audiences": basetypes.SetType{
+				ElemType: types.StringType,
+			},
+			"service_account_issuer": basetypes.StringType{},
+		}), diags
+	}
+
+	attributeTypes := map[string]attr.Type{
+		"api_audiences": basetypes.SetType{
+			ElemType: types.StringType,
+		},
+		"service_account_issuer": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"api_audiences":          apiAudiencesVal,
+			"service_account_issuer": v.ServiceAccountIssuer,
+		})
+
+	return objVal, diags
+}
+
+func (v OidcConfigurationValue) Equal(o attr.Value) bool {
+	other, ok := o.(OidcConfigurationValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.ApiAudiences.Equal(other.ApiAudiences) {
+		return false
+	}
+
+	if !v.ServiceAccountIssuer.Equal(other.ServiceAccountIssuer) {
+		return false
+	}
+
+	return true
+}
+
+func (v OidcConfigurationValue) Type(ctx context.Context) attr.Type {
+	return OidcConfigurationType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v OidcConfigurationValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"api_audiences": basetypes.SetType{
+			ElemType: types.StringType,
+		},
+		"service_account_issuer": basetypes.StringType{},
+	}
+}
+
 var _ basetypes.ObjectTypable = ProxyType{}
 
 type ProxyType struct {
@@ -13782,399 +14188,5 @@ func (v TolerationsValue) AttributeTypes(ctx context.Context) map[string]attr.Ty
 		"operator":           basetypes.StringType{},
 		"toleration_seconds": basetypes.Int64Type{},
 		"value":              basetypes.StringType{},
-	}
-}
-
-var _ basetypes.ObjectTypable = OidcConfigurationType{}
-
-type OidcConfigurationType struct {
-	basetypes.ObjectType
-}
-
-func (t OidcConfigurationType) Equal(o attr.Type) bool {
-	other, ok := o.(OidcConfigurationType)
-
-	if !ok {
-		return false
-	}
-
-	return t.ObjectType.Equal(other.ObjectType)
-}
-
-func (t OidcConfigurationType) String() string {
-	return "OidcConfigurationType"
-}
-
-func (t OidcConfigurationType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
-	var diags diag.Diagnostics
-
-	attributes := in.Attributes()
-
-	apiAudiencesAttribute, ok := attributes["api_audiences"]
-
-	if !ok {
-		diags.AddError(
-			"Attribute Missing",
-			`api_audiences is missing from object`)
-
-		return nil, diags
-	}
-
-	apiAudiencesVal, ok := apiAudiencesAttribute.(basetypes.SetValue)
-
-	if !ok {
-		diags.AddError(
-			"Attribute Wrong Type",
-			fmt.Sprintf(`api_audiences expected to be basetypes.SetValue, was: %T`, apiAudiencesAttribute))
-	}
-
-	serviceAccountIssuerAttribute, ok := attributes["service_account_issuer"]
-
-	if !ok {
-		diags.AddError(
-			"Attribute Missing",
-			`service_account_issuer is missing from object`)
-
-		return nil, diags
-	}
-
-	serviceAccountIssuerVal, ok := serviceAccountIssuerAttribute.(basetypes.StringValue)
-
-	if !ok {
-		diags.AddError(
-			"Attribute Wrong Type",
-			fmt.Sprintf(`service_account_issuer expected to be basetypes.StringValue, was: %T`, serviceAccountIssuerAttribute))
-	}
-
-	if diags.HasError() {
-		return nil, diags
-	}
-
-	return OidcConfigurationValue{
-		ApiAudiences:         apiAudiencesVal,
-		ServiceAccountIssuer: serviceAccountIssuerVal,
-		state:                attr.ValueStateKnown,
-	}, diags
-}
-
-func NewOidcConfigurationValueNull() OidcConfigurationValue {
-	return OidcConfigurationValue{
-		state: attr.ValueStateNull,
-	}
-}
-
-func NewOidcConfigurationValueUnknown() OidcConfigurationValue {
-	return OidcConfigurationValue{
-		state: attr.ValueStateUnknown,
-	}
-}
-
-func NewOidcConfigurationValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (OidcConfigurationValue, diag.Diagnostics) {
-	var diags diag.Diagnostics
-
-	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
-	ctx := context.Background()
-
-	for name, attributeType := range attributeTypes {
-		attribute, ok := attributes[name]
-
-		if !ok {
-			diags.AddError(
-				"Missing OidcConfigurationValue Attribute Value",
-				"While creating a OidcConfigurationValue value, a missing attribute value was detected. "+
-					"A OidcConfigurationValue must contain values for all attributes, even if null or unknown. "+
-					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
-					fmt.Sprintf("OidcConfigurationValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
-			)
-
-			continue
-		}
-
-		if !attributeType.Equal(attribute.Type(ctx)) {
-			diags.AddError(
-				"Invalid OidcConfigurationValue Attribute Type",
-				"While creating a OidcConfigurationValue value, an invalid attribute value was detected. "+
-					"A OidcConfigurationValue must use a matching attribute type for the value. "+
-					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
-					fmt.Sprintf("OidcConfigurationValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
-					fmt.Sprintf("OidcConfigurationValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
-			)
-		}
-	}
-
-	for name := range attributes {
-		_, ok := attributeTypes[name]
-
-		if !ok {
-			diags.AddError(
-				"Extra OidcConfigurationValue Attribute Value",
-				"While creating a OidcConfigurationValue value, an extra attribute value was detected. "+
-					"A OidcConfigurationValue must not contain values beyond the expected attribute types. "+
-					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
-					fmt.Sprintf("Extra OidcConfigurationValue Attribute Name: %s", name),
-			)
-		}
-	}
-
-	if diags.HasError() {
-		return NewOidcConfigurationValueUnknown(), diags
-	}
-
-	apiAudiencesAttribute, ok := attributes["api_audiences"]
-
-	if !ok {
-		diags.AddError(
-			"Attribute Missing",
-			`api_audiences is missing from object`)
-
-		return NewOidcConfigurationValueUnknown(), diags
-	}
-
-	apiAudiencesVal, ok := apiAudiencesAttribute.(basetypes.SetValue)
-
-	if !ok {
-		diags.AddError(
-			"Attribute Wrong Type",
-			fmt.Sprintf(`api_audiences expected to be basetypes.SetValue, was: %T`, apiAudiencesAttribute))
-	}
-
-	serviceAccountIssuerAttribute, ok := attributes["service_account_issuer"]
-
-	if !ok {
-		diags.AddError(
-			"Attribute Missing",
-			`service_account_issuer is missing from object`)
-
-		return NewOidcConfigurationValueUnknown(), diags
-	}
-
-	serviceAccountIssuerVal, ok := serviceAccountIssuerAttribute.(basetypes.StringValue)
-
-	if !ok {
-		diags.AddError(
-			"Attribute Wrong Type",
-			fmt.Sprintf(`service_account_issuer expected to be basetypes.StringValue, was: %T`, serviceAccountIssuerAttribute))
-	}
-
-	if diags.HasError() {
-		return NewOidcConfigurationValueUnknown(), diags
-	}
-
-	return OidcConfigurationValue{
-		ApiAudiences:         apiAudiencesVal,
-		ServiceAccountIssuer: serviceAccountIssuerVal,
-		state:                attr.ValueStateKnown,
-	}, diags
-}
-
-func NewOidcConfigurationValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) OidcConfigurationValue {
-	object, diags := NewOidcConfigurationValue(attributeTypes, attributes)
-
-	if diags.HasError() {
-		diagsStrings := make([]string, 0, len(diags))
-
-		for _, diagnostic := range diags {
-			diagsStrings = append(diagsStrings, fmt.Sprintf(
-				"%s | %s | %s",
-				diagnostic.Severity(),
-				diagnostic.Summary(),
-				diagnostic.Detail()))
-		}
-
-		panic("NewOidcConfigurationValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
-	}
-
-	return object
-}
-
-func (t OidcConfigurationType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
-	if in.Type() == nil {
-		return NewOidcConfigurationValueNull(), nil
-	}
-
-	if !in.Type().Equal(t.TerraformType(ctx)) {
-		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
-	}
-
-	if !in.IsKnown() {
-		return NewOidcConfigurationValueUnknown(), nil
-	}
-
-	if in.IsNull() {
-		return NewOidcConfigurationValueNull(), nil
-	}
-
-	attributes := map[string]attr.Value{}
-
-	val := map[string]tftypes.Value{}
-
-	err := in.As(&val)
-
-	if err != nil {
-		return nil, err
-	}
-
-	for k, v := range val {
-		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
-		if err != nil {
-			return nil, err
-		}
-
-		attributes[k] = a
-	}
-
-	return NewOidcConfigurationValueMust(OidcConfigurationValue{}.AttributeTypes(ctx), attributes), nil
-}
-
-func (t OidcConfigurationType) ValueType(ctx context.Context) attr.Value {
-	return OidcConfigurationValue{}
-}
-
-var _ basetypes.ObjectValuable = OidcConfigurationValue{}
-
-type OidcConfigurationValue struct {
-	ApiAudiences         basetypes.SetValue    `tfsdk:"api_audiences"`
-	ServiceAccountIssuer basetypes.StringValue `tfsdk:"service_account_issuer"`
-	state                attr.ValueState
-}
-
-func (v OidcConfigurationValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 2)
-
-	var val tftypes.Value
-	var err error
-
-	attrTypes["api_audiences"] = basetypes.SetType{
-		ElemType: types.StringType,
-	}.TerraformType(ctx)
-	attrTypes["service_account_issuer"] = basetypes.StringType{}.TerraformType(ctx)
-
-	objectType := tftypes.Object{AttributeTypes: attrTypes}
-
-	switch v.state {
-	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 2)
-
-		val, err = v.ApiAudiences.ToTerraformValue(ctx)
-
-		if err != nil {
-			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
-		}
-
-		vals["api_audiences"] = val
-
-		val, err = v.ServiceAccountIssuer.ToTerraformValue(ctx)
-
-		if err != nil {
-			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
-		}
-
-		vals["service_account_issuer"] = val
-
-		if err := tftypes.ValidateValue(objectType, vals); err != nil {
-			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
-		}
-
-		return tftypes.NewValue(objectType, vals), nil
-	case attr.ValueStateNull:
-		return tftypes.NewValue(objectType, nil), nil
-	case attr.ValueStateUnknown:
-		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
-	default:
-		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
-	}
-}
-
-func (v OidcConfigurationValue) IsNull() bool {
-	return v.state == attr.ValueStateNull
-}
-
-func (v OidcConfigurationValue) IsUnknown() bool {
-	return v.state == attr.ValueStateUnknown
-}
-
-func (v OidcConfigurationValue) String() string {
-	return "OidcConfigurationValue"
-}
-
-func (v OidcConfigurationValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
-	var diags diag.Diagnostics
-
-	apiAudiencesVal := types.SetValueMust(types.StringType, v.ApiAudiences.Elements())
-
-	if v.ApiAudiences.IsNull() {
-		apiAudiencesVal = types.SetNull(types.StringType)
-	}
-
-	if v.ApiAudiences.IsUnknown() {
-		apiAudiencesVal = types.SetUnknown(types.StringType)
-	}
-
-	attributeTypes := map[string]attr.Type{
-		"api_audiences": basetypes.SetType{
-			ElemType: types.StringType,
-		},
-		"service_account_issuer": basetypes.StringType{},
-	}
-
-	if v.IsNull() {
-		return types.ObjectNull(attributeTypes), diags
-	}
-
-	if v.IsUnknown() {
-		return types.ObjectUnknown(attributeTypes), diags
-	}
-
-	objVal, diags := types.ObjectValue(
-		attributeTypes,
-		map[string]attr.Value{
-			"api_audiences":          apiAudiencesVal,
-			"service_account_issuer": v.ServiceAccountIssuer,
-		})
-
-	return objVal, diags
-}
-
-func (v OidcConfigurationValue) Equal(o attr.Value) bool {
-	other, ok := o.(OidcConfigurationValue)
-
-	if !ok {
-		return false
-	}
-
-	if v.state != other.state {
-		return false
-	}
-
-	if v.state != attr.ValueStateKnown {
-		return true
-	}
-
-	if !v.ApiAudiences.Equal(other.ApiAudiences) {
-		return false
-	}
-
-	if !v.ServiceAccountIssuer.Equal(other.ServiceAccountIssuer) {
-		return false
-	}
-
-	return true
-}
-
-func (v OidcConfigurationValue) Type(ctx context.Context) attr.Type {
-	return OidcConfigurationType{
-		basetypes.ObjectType{
-			AttrTypes: v.AttributeTypes(ctx),
-		},
-	}
-}
-
-func (v OidcConfigurationValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
-	return map[string]attr.Type{
-		"api_audiences": basetypes.SetType{
-			ElemType: types.StringType,
-		},
-		"service_account_issuer": basetypes.StringType{},
 	}
 }

--- a/rafay/eks_config.go
+++ b/rafay/eks_config.go
@@ -1115,7 +1115,9 @@ type ManagedNodeGroup struct {
 	// networking](/usage/vpc-networking/#use-private-subnets-for-initial-nodegroup)
 	// for nodegroup
 	// +optional
-	PrivateNetworking *bool `yaml:"privateNetworking"`
+	//PrivateNetworking *bool `yaml:"privateNetworking"`
+	// +optional
+	PrivateNetworking *bool `yaml:"privateNetworking,omitempty"`
 	// Applied to the Autoscaling Group and to the EC2 instances (unmanaged),
 	// Applied to the EKS Nodegroup resource and to the EC2 instances (managed)
 	// +optional


### PR DESCRIPTION
https://rafaysystems.atlassian.net/browse/RC-51061
