### PR TITLE
RC-51061: EKS: terraform apply blocked after terraform import of rafay_eks_cluster: schema defaults force update to immutable nodegroup fields (volumeIOPS, volumeThroughput)

### DIFF
--- a/internal/resource_eks_cluster/eks_cluster_resource_flatten.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_flatten.go
@@ -1187,9 +1187,13 @@ func (v *PrivateClusterValue) Flatten(ctx context.Context, in *rafay.PrivateClus
 
 	if in.Enabled != nil {
 		v.Enabled = types.BoolPointerValue(in.Enabled)
+	} else {
+		v.Enabled = types.BoolValue(false)
 	}
 	if in.SkipEndpointCreation != nil {
 		v.SkipEndpointCreation = types.BoolPointerValue(in.SkipEndpointCreation)
+	} else {
+		v.SkipEndpointCreation = types.BoolValue(false)
 	}
 	additionalEndpointServices := types.ListNull(types.StringType)
 	if len(in.AdditionalEndpointServices) > 0 {
@@ -1422,24 +1426,38 @@ func (v *WellKnownPolicies4Value) Flatten(ctx context.Context, in *rafay.WellKno
 
 	if in.ImageBuilder != nil {
 		v.ImageBuilder = types.BoolPointerValue(in.ImageBuilder)
+	} else {
+		v.ImageBuilder = types.BoolValue(false)
 	}
 	if in.AutoScaler != nil {
 		v.AutoScaler = types.BoolPointerValue(in.AutoScaler)
+	} else {
+		v.AutoScaler = types.BoolValue(false)
 	}
 	if in.AWSLoadBalancerController != nil {
 		v.AwsLoadBalancerController = types.BoolPointerValue(in.AWSLoadBalancerController)
+	} else {
+		v.AwsLoadBalancerController = types.BoolValue(false)
 	}
 	if in.ExternalDNS != nil {
 		v.ExternalDns = types.BoolPointerValue(in.ExternalDNS)
+	} else {
+		v.ExternalDns = types.BoolValue(false)
 	}
 	if in.CertManager != nil {
 		v.CertManager = types.BoolPointerValue(in.CertManager)
+	} else {
+		v.CertManager = types.BoolValue(false)
 	}
 	if in.EBSCSIController != nil {
 		v.EbsCsiController = types.BoolPointerValue(in.EBSCSIController)
+	} else {
+		v.EbsCsiController = types.BoolValue(false)
 	}
 	if in.EFSCSIController != nil {
 		v.EfsCsiController = types.BoolPointerValue(in.EFSCSIController)
+	} else {
+		v.EfsCsiController = types.BoolValue(false)
 	}
 
 	v.state = attr.ValueStateKnown
@@ -1454,24 +1472,38 @@ func (v *WellKnownPolicies3Value) Flatten(ctx context.Context, in *rafay.WellKno
 
 	if in.ImageBuilder != nil {
 		v.ImageBuilder = types.BoolPointerValue(in.ImageBuilder)
+	} else {
+		v.ImageBuilder = types.BoolValue(false)
 	}
 	if in.AutoScaler != nil {
 		v.AutoScaler = types.BoolPointerValue(in.AutoScaler)
+	} else {
+		v.AutoScaler = types.BoolValue(false)
 	}
 	if in.AWSLoadBalancerController != nil {
 		v.AwsLoadBalancerController = types.BoolPointerValue(in.AWSLoadBalancerController)
+	} else {
+		v.AwsLoadBalancerController = types.BoolValue(false)
 	}
 	if in.ExternalDNS != nil {
 		v.ExternalDns = types.BoolPointerValue(in.ExternalDNS)
+	} else {
+		v.ExternalDns = types.BoolValue(false)
 	}
 	if in.CertManager != nil {
 		v.CertManager = types.BoolPointerValue(in.CertManager)
+	} else {
+		v.CertManager = types.BoolValue(false)
 	}
 	if in.EBSCSIController != nil {
 		v.EbsCsiController = types.BoolPointerValue(in.EBSCSIController)
+	} else {
+		v.EbsCsiController = types.BoolValue(false)
 	}
 	if in.EFSCSIController != nil {
 		v.EfsCsiController = types.BoolPointerValue(in.EFSCSIController)
+	} else {
+		v.EfsCsiController = types.BoolValue(false)
 	}
 
 	v.state = attr.ValueStateKnown
@@ -1986,24 +2018,38 @@ func (v *WellKnownPolicies2Value) Flatten(ctx context.Context, in *rafay.WellKno
 
 	if in.ImageBuilder != nil {
 		v.ImageBuilder = types.BoolPointerValue(in.ImageBuilder)
+	} else {
+		v.ImageBuilder = types.BoolValue(false)
 	}
 	if in.AutoScaler != nil {
 		v.AutoScaler = types.BoolPointerValue(in.AutoScaler)
+	} else {
+		v.AutoScaler = types.BoolValue(false)
 	}
 	if in.AWSLoadBalancerController != nil {
 		v.AwsLoadBalancerController = types.BoolPointerValue(in.AWSLoadBalancerController)
+	} else {
+		v.AwsLoadBalancerController = types.BoolValue(false)
 	}
 	if in.ExternalDNS != nil {
 		v.ExternalDns = types.BoolPointerValue(in.ExternalDNS)
+	} else {
+		v.ExternalDns = types.BoolValue(false)
 	}
 	if in.CertManager != nil {
 		v.CertManager = types.BoolPointerValue(in.CertManager)
+	} else {
+		v.CertManager = types.BoolValue(false)
 	}
 	if in.EBSCSIController != nil {
 		v.EbsCsiController = types.BoolPointerValue(in.EBSCSIController)
+	} else {
+		v.EbsCsiController = types.BoolValue(false)
 	}
 	if in.EFSCSIController != nil {
 		v.EfsCsiController = types.BoolPointerValue(in.EFSCSIController)
+	} else {
+		v.EfsCsiController = types.BoolValue(false)
 	}
 
 	v.state = attr.ValueStateKnown
@@ -2124,24 +2170,38 @@ func (v *WellKnownPoliciesValue) Flatten(ctx context.Context, in *rafay.WellKnow
 
 	if in.ImageBuilder != nil {
 		v.ImageBuilder = types.BoolPointerValue(in.ImageBuilder)
+	} else {
+		v.ImageBuilder = types.BoolValue(false)
 	}
 	if in.AutoScaler != nil {
 		v.AutoScaler = types.BoolPointerValue(in.AutoScaler)
+	} else {
+		v.AutoScaler = types.BoolValue(false)
 	}
 	if in.AWSLoadBalancerController != nil {
 		v.AwsLoadBalancerController = types.BoolPointerValue(in.AWSLoadBalancerController)
+	} else {
+		v.AwsLoadBalancerController = types.BoolValue(false)
 	}
 	if in.ExternalDNS != nil {
 		v.ExternalDns = types.BoolPointerValue(in.ExternalDNS)
+	} else {
+		v.ExternalDns = types.BoolValue(false)
 	}
 	if in.CertManager != nil {
 		v.CertManager = types.BoolPointerValue(in.CertManager)
+	} else {
+		v.CertManager = types.BoolValue(false)
 	}
 	if in.EBSCSIController != nil {
 		v.EbsCsiController = types.BoolPointerValue(in.EBSCSIController)
+	} else {
+		v.EbsCsiController = types.BoolValue(false)
 	}
 	if in.EFSCSIController != nil {
 		v.EfsCsiController = types.BoolPointerValue(in.EFSCSIController)
+	} else {
+		v.EfsCsiController = types.BoolValue(false)
 	}
 
 	v.state = attr.ValueStateKnown

--- a/internal/resource_eks_cluster/eks_cluster_resource_flatten.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_flatten.go
@@ -2426,13 +2426,18 @@ func (v *SharingValue) Flatten(ctx context.Context, in *rafay.V1ClusterSharing) 
 	if len(in.Projects) > 0 {
 		projectsList := make([]attr.Value, 0, len(in.Projects))
 		for _, p := range in.Projects {
+			if p == nil || p.Name == "" {
+				continue
+			}
 			proj := NewProjectsValueNull()
 			d = proj.Flatten(ctx, p)
 			diags = append(diags, d...)
 			projectsList = append(projectsList, proj)
 		}
-		projects, d = types.ListValue(ProjectsValue{}.Type(ctx), projectsList)
-		diags = append(diags, d...)
+		if len(projectsList) > 0 {
+			projects, d = types.ListValue(ProjectsValue{}.Type(ctx), projectsList)
+			diags = append(diags, d...)
+		}
 	}
 	v.Projects = projects
 

--- a/internal/resource_eks_cluster/eks_cluster_resource_flatten.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_flatten.go
@@ -694,7 +694,8 @@ func (v *ClusterConfigValue) Flatten(ctx context.Context, in rafay.EKSClusterCon
 		v.AddonsConfig = types.ListNull(AddonsConfigValue{}.Type(ctx))
 	}
 
-	if in.AutoModeConfig != nil {
+	//	if in.AutoModeConfig != nil {
+	if in.AutoModeConfig != nil && isAutoModeConfigPresent(in.AutoModeConfig) {
 		autoModeConfig := NewAutoModeConfigValueNull()
 		d = autoModeConfig.Flatten(ctx, in.AutoModeConfig)
 		diags = append(diags, d...)
@@ -759,7 +760,6 @@ func (v *AutoModeConfigValue) Flatten(ctx context.Context, in *rafay.EKSAutoMode
 		diags = append(diags, d...)
 	}
 	v.NodePools = nodePools
-
 	v.state = attr.ValueStateKnown
 	return diags
 }
@@ -1638,6 +1638,8 @@ func (v *VpcValue) Flatten(ctx context.Context, in *rafay.EKSClusterVPC) diag.Di
 	}
 	if in.AutoAllocateIPv6 != nil {
 		v.AutoAllocateIpv6 = types.BoolPointerValue(in.AutoAllocateIPv6)
+	} else {
+		v.AutoAllocateIpv6 = types.BoolValue(false)
 	}
 
 	publicAccessCidrs := types.ListNull(types.StringType)
@@ -1911,7 +1913,11 @@ func (v *ServiceAccountsValue) Flatten(ctx context.Context, in *rafay.EKSCluster
 	if in.RoleName != "" {
 		v.RoleName = types.StringValue(in.RoleName)
 	}
-	v.RoleOnly = types.BoolPointerValue(in.RoleOnly)
+	if in.RoleOnly != nil {
+		v.RoleOnly = types.BoolPointerValue(in.RoleOnly)
+	} else {
+		v.RoleOnly = types.BoolValue(false)
+	}
 
 	tagMap := types.MapNull(types.StringType)
 	if len(in.Tags) != 0 {
@@ -2386,4 +2392,12 @@ func (v *ProjectsValue) Flatten(ctx context.Context, in *rafay.V1ClusterSharingP
 
 	v.state = attr.ValueStateKnown
 	return diags
+}
+
+func isAutoModeConfigPresent(in *rafay.EKSAutoModeConfig) bool {
+	if in == nil {
+		return false
+	}
+	// only keep in state if something real is set
+	return in.Enabled || in.NodeRoleARN != "" || len(in.NodePools) > 0
 }

--- a/internal/resource_eks_cluster/eks_cluster_resource_flatten_managednodegroup.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_flatten_managednodegroup.go
@@ -28,12 +28,18 @@ func (v *ManagedNodegroupsValue) Flatten(ctx context.Context, in *rafay.ManagedN
 	}
 	if in.DisableIMDSv1 != nil {
 		v.DisableImdsv1 = types.BoolValue(*in.DisableIMDSv1)
+	} else {
+		v.DisableImdsv1 = types.BoolValue(false)
 	}
 	if in.DisablePodIMDS != nil {
 		v.DisablePodsImds = types.BoolValue(*in.DisablePodIMDS)
+	} else {
+		v.DisablePodsImds = types.BoolValue(false)
 	}
 	if in.EFAEnabled != nil {
 		v.EfaEnabled = types.BoolValue(*in.EFAEnabled)
+	} else {
+		v.EfaEnabled = types.BoolValue(false)
 	}
 	if in.InstanceType != "" {
 		v.InstanceType = types.StringValue(in.InstanceType)
@@ -49,6 +55,8 @@ func (v *ManagedNodegroupsValue) Flatten(ctx context.Context, in *rafay.ManagedN
 	}
 	if in.PrivateNetworking != nil {
 		v.PrivateNetworking = types.BoolValue(*in.PrivateNetworking)
+	} else {
+		v.PrivateNetworking = types.BoolValue(false)
 	}
 	if in.Version != "" {
 		v.Version = types.StringValue(in.Version)
@@ -67,12 +75,16 @@ func (v *ManagedNodegroupsValue) Flatten(ctx context.Context, in *rafay.ManagedN
 	}
 	if in.EBSOptimized != nil {
 		v.EbsOptimized = types.BoolValue(*in.EBSOptimized)
+	} else {
+		v.EbsOptimized = types.BoolValue(false)
 	}
 	if in.VolumeName != "" {
 		v.VolumeName = types.StringValue(in.VolumeName)
 	}
 	if in.VolumeEncrypted != nil {
 		v.VolumeEncrypted = types.BoolValue(*in.VolumeEncrypted)
+	} else {
+		v.VolumeEncrypted = types.BoolValue(false)
 	}
 	if in.VolumeKmsKeyID != "" {
 		v.VolumeKmsKeyId = types.StringValue(in.VolumeKmsKeyID)
@@ -105,6 +117,8 @@ func (v *ManagedNodegroupsValue) Flatten(ctx context.Context, in *rafay.ManagedN
 
 	if in.EnableDetailedMonitoring != nil {
 		v.EnableDetailedMonitoring = types.BoolPointerValue(in.EnableDetailedMonitoring)
+	} else {
+		v.EnableDetailedMonitoring = types.BoolValue(false)
 	}
 
 	availabilityZones := types.ListNull(types.StringType)
@@ -163,6 +177,8 @@ func (v *ManagedNodegroupsValue) Flatten(ctx context.Context, in *rafay.ManagedN
 	}
 	if in.Spot != nil {
 		v.Spot = types.BoolPointerValue(in.Spot)
+	} else {
+		v.Spot = types.BoolValue(false)
 	}
 
 	instanceTypes := types.ListNull(types.StringType)
@@ -629,39 +645,63 @@ func (v *IamNodeGroupWithAddonPolicies4Value) Flatten(ctx context.Context, in *r
 
 	if in.AWSLoadBalancerController != nil {
 		v.AlbIngress = types.BoolPointerValue(in.AWSLoadBalancerController)
+	} else {
+		v.AlbIngress = types.BoolValue(false)
 	}
 	if in.AppMesh != nil {
 		v.AppMesh = types.BoolPointerValue(in.AppMesh)
+	} else {
+		v.AppMesh = types.BoolValue(false)
 	}
 	if in.AppMeshPreview != nil {
 		v.AppMeshReview = types.BoolPointerValue(in.AppMeshPreview)
+	} else {
+		v.AppMeshReview = types.BoolValue(false)
 	}
 	if in.AutoScaler != nil {
 		v.AutoScaler = types.BoolPointerValue(in.AutoScaler)
+	} else {
+		v.AutoScaler = types.BoolValue(true)
 	}
 	if in.CertManager != nil {
 		v.CertManager = types.BoolPointerValue(in.CertManager)
+	} else {
+		v.CertManager = types.BoolValue(false)
 	}
 	if in.CloudWatch != nil {
 		v.CloudWatch = types.BoolPointerValue(in.CloudWatch)
+	} else {
+		v.CloudWatch = types.BoolValue(false)
 	}
 	if in.EBS != nil {
 		v.Ebs = types.BoolPointerValue(in.EBS)
+	} else {
+		v.Ebs = types.BoolValue(false)
 	}
 	if in.EFS != nil {
 		v.Efs = types.BoolPointerValue(in.EFS)
+	} else {
+		v.Efs = types.BoolValue(false)
 	}
 	if in.ExternalDNS != nil {
 		v.ExternalDns = types.BoolPointerValue(in.ExternalDNS)
+	} else {
+		v.ExternalDns = types.BoolValue(false)
 	}
 	if in.FSX != nil {
 		v.Fsx = types.BoolPointerValue(in.FSX)
+	} else {
+		v.Fsx = types.BoolValue(false)
 	}
 	if in.ImageBuilder != nil {
 		v.ImageBuilder = types.BoolPointerValue(in.ImageBuilder)
+	} else {
+		v.ImageBuilder = types.BoolValue(true)
 	}
 	if in.XRay != nil {
 		v.Xray = types.BoolPointerValue(in.XRay)
+	} else {
+		v.Xray = types.BoolValue(false)
 	}
 
 	v.state = attr.ValueStateKnown

--- a/internal/resource_eks_cluster/eks_cluster_resource_flatten_managednodegroup.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_flatten_managednodegroup.go
@@ -55,8 +55,6 @@ func (v *ManagedNodegroupsValue) Flatten(ctx context.Context, in *rafay.ManagedN
 	}
 	if in.PrivateNetworking != nil {
 		v.PrivateNetworking = types.BoolValue(*in.PrivateNetworking)
-	} else {
-		v.PrivateNetworking = types.BoolValue(false)
 	}
 	if in.Version != "" {
 		v.Version = types.StringValue(in.Version)

--- a/internal/resource_eks_cluster/eks_cluster_resource_flatten_managednodegroup_map.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_flatten_managednodegroup_map.go
@@ -52,8 +52,6 @@ func (v *ManagedNodegroupsMapValue) Flatten(ctx context.Context, in *rafay.Manag
 	}
 	if in.PrivateNetworking != nil {
 		v.PrivateNetworking = types.BoolValue(*in.PrivateNetworking)
-	} else {
-		v.PrivateNetworking = types.BoolValue(false)
 	}
 	if in.Version != "" {
 		v.Version = types.StringValue(in.Version)

--- a/internal/resource_eks_cluster/eks_cluster_resource_flatten_managednodegroup_map.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_flatten_managednodegroup_map.go
@@ -25,12 +25,18 @@ func (v *ManagedNodegroupsMapValue) Flatten(ctx context.Context, in *rafay.Manag
 	}
 	if in.DisableIMDSv1 != nil {
 		v.DisableImdsv1 = types.BoolValue(*in.DisableIMDSv1)
+	} else {
+		v.DisableImdsv1 = types.BoolValue(false)
 	}
 	if in.DisablePodIMDS != nil {
 		v.DisablePodsImds = types.BoolValue(*in.DisablePodIMDS)
+	} else {
+		v.DisablePodsImds = types.BoolValue(false)
 	}
 	if in.EFAEnabled != nil {
 		v.EfaEnabled = types.BoolValue(*in.EFAEnabled)
+	} else {
+		v.EfaEnabled = types.BoolValue(false)
 	}
 	if in.InstanceType != "" {
 		v.InstanceType = types.StringValue(in.InstanceType)
@@ -46,6 +52,8 @@ func (v *ManagedNodegroupsMapValue) Flatten(ctx context.Context, in *rafay.Manag
 	}
 	if in.PrivateNetworking != nil {
 		v.PrivateNetworking = types.BoolValue(*in.PrivateNetworking)
+	} else {
+		v.PrivateNetworking = types.BoolValue(false)
 	}
 	if in.Version != "" {
 		v.Version = types.StringValue(in.Version)
@@ -64,12 +72,16 @@ func (v *ManagedNodegroupsMapValue) Flatten(ctx context.Context, in *rafay.Manag
 	}
 	if in.EBSOptimized != nil {
 		v.EbsOptimized = types.BoolValue(*in.EBSOptimized)
+	} else {
+		v.EbsOptimized = types.BoolValue(false)
 	}
 	if in.VolumeName != "" {
 		v.VolumeName = types.StringValue(in.VolumeName)
 	}
 	if in.VolumeEncrypted != nil {
 		v.VolumeEncrypted = types.BoolValue(*in.VolumeEncrypted)
+	} else {
+		v.VolumeEncrypted = types.BoolValue(false)
 	}
 	if in.VolumeKmsKeyID != "" {
 		v.VolumeKmsKeyId = types.StringValue(in.VolumeKmsKeyID)
@@ -102,6 +114,8 @@ func (v *ManagedNodegroupsMapValue) Flatten(ctx context.Context, in *rafay.Manag
 
 	if in.EnableDetailedMonitoring != nil {
 		v.EnableDetailedMonitoring = types.BoolPointerValue(in.EnableDetailedMonitoring)
+	} else {
+		v.EnableDetailedMonitoring = types.BoolValue(false)
 	}
 	if len(in.AvailabilityZones) > 0 {
 		azElements := []attr.Value{}
@@ -160,6 +174,8 @@ func (v *ManagedNodegroupsMapValue) Flatten(ctx context.Context, in *rafay.Manag
 	}
 	if in.Spot != nil {
 		v.Spot = types.BoolPointerValue(in.Spot)
+	} else {
+		v.Spot = types.BoolValue(false)
 	}
 
 	if len(in.InstanceTypes) > 0 {
@@ -437,39 +453,63 @@ func (v *IamNodeGroupWithAddonPolicies5Value) Flatten(ctx context.Context, in *r
 
 	if in.AWSLoadBalancerController != nil {
 		v.AlbIngress = types.BoolPointerValue(in.AWSLoadBalancerController)
+	} else {
+		v.AlbIngress = types.BoolValue(false)
 	}
 	if in.AppMesh != nil {
 		v.AppMesh = types.BoolPointerValue(in.AppMesh)
+	} else {
+		v.AppMesh = types.BoolValue(false)
 	}
 	if in.AppMeshPreview != nil {
 		v.AppMeshReview = types.BoolPointerValue(in.AppMeshPreview)
+	} else {
+		v.AppMeshReview = types.BoolValue(false)
 	}
 	if in.AutoScaler != nil {
 		v.AutoScaler = types.BoolPointerValue(in.AutoScaler)
+	} else {
+		v.AutoScaler = types.BoolValue(true)
 	}
 	if in.CertManager != nil {
 		v.CertManager = types.BoolPointerValue(in.CertManager)
+	} else {
+		v.CertManager = types.BoolValue(false)
 	}
 	if in.CloudWatch != nil {
 		v.CloudWatch = types.BoolPointerValue(in.CloudWatch)
+	} else {
+		v.CloudWatch = types.BoolValue(false)
 	}
 	if in.EBS != nil {
 		v.Ebs = types.BoolPointerValue(in.EBS)
+	} else {
+		v.Ebs = types.BoolValue(false)
 	}
 	if in.EFS != nil {
 		v.Efs = types.BoolPointerValue(in.EFS)
+	} else {
+		v.Efs = types.BoolValue(false)
 	}
 	if in.ExternalDNS != nil {
 		v.ExternalDns = types.BoolPointerValue(in.ExternalDNS)
+	} else {
+		v.ExternalDns = types.BoolValue(false)
 	}
 	if in.FSX != nil {
 		v.Fsx = types.BoolPointerValue(in.FSX)
+	} else {
+		v.Fsx = types.BoolValue(false)
 	}
 	if in.ImageBuilder != nil {
 		v.ImageBuilder = types.BoolPointerValue(in.ImageBuilder)
+	} else {
+		v.ImageBuilder = types.BoolValue(true)
 	}
 	if in.XRay != nil {
 		v.Xray = types.BoolPointerValue(in.XRay)
+	} else {
+		v.Xray = types.BoolValue(false)
 	}
 
 	v.state = attr.ValueStateKnown

--- a/internal/resource_eks_cluster/eks_cluster_resource_flatten_nodegroup.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_flatten_nodegroup.go
@@ -64,8 +64,6 @@ func (v *NodeGroupsValue) Flatten(ctx context.Context, in *rafay.NodeGroup, stat
 	}
 	if in.PrivateNetworking != nil {
 		v.PrivateNetworking = types.BoolPointerValue(in.PrivateNetworking)
-	} else {
-		v.PrivateNetworking = types.BoolValue(false)
 	}
 	if in.Version != "" {
 		v.Version = types.StringValue(in.Version)
@@ -638,9 +636,13 @@ func (v *SecurityGroupsValue) Flatten(ctx context.Context, in *rafay.NodeGroupSG
 
 	if in.WithShared != nil {
 		v.WithShared = types.BoolPointerValue(in.WithShared)
+	} else {
+		v.WithShared = types.BoolValue(true)
 	}
 	if in.WithLocal != nil {
 		v.WithLocal = types.BoolPointerValue(in.WithLocal)
+	} else {
+		v.WithLocal = types.BoolValue(true)
 	}
 
 	attachIds := types.ListNull(types.StringType)

--- a/internal/resource_eks_cluster/eks_cluster_resource_flatten_nodegroup.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_flatten_nodegroup.go
@@ -28,12 +28,18 @@ func (v *NodeGroupsValue) Flatten(ctx context.Context, in *rafay.NodeGroup, stat
 	}
 	if in.DisableIMDSv1 != nil {
 		v.DisableImdsv1 = types.BoolPointerValue(in.DisableIMDSv1)
+	} else {
+		v.DisableImdsv1 = types.BoolValue(false)
 	}
 	if in.DisablePodIMDS != nil {
 		v.DisablePodsImds = types.BoolPointerValue(in.DisablePodIMDS)
+	} else {
+		v.DisablePodsImds = types.BoolValue(false)
 	}
 	if in.EFAEnabled != nil {
 		v.EfaEnabled = types.BoolPointerValue(in.EFAEnabled)
+	} else {
+		v.EfaEnabled = types.BoolValue(false)
 	}
 	if in.InstanceType != "" {
 		v.InstanceType = types.StringValue(in.InstanceType)
@@ -58,6 +64,8 @@ func (v *NodeGroupsValue) Flatten(ctx context.Context, in *rafay.NodeGroup, stat
 	}
 	if in.PrivateNetworking != nil {
 		v.PrivateNetworking = types.BoolPointerValue(in.PrivateNetworking)
+	} else {
+		v.PrivateNetworking = types.BoolValue(false)
 	}
 	if in.Version != "" {
 		v.Version = types.StringValue(in.Version)
@@ -79,6 +87,8 @@ func (v *NodeGroupsValue) Flatten(ctx context.Context, in *rafay.NodeGroup, stat
 	}
 	if in.EBSOptimized != nil {
 		v.EbsOptimized = types.BoolPointerValue(in.EBSOptimized)
+	} else {
+		v.EbsOptimized = types.BoolValue(false)
 	}
 
 	if in.VolumeName != "" {
@@ -86,6 +96,8 @@ func (v *NodeGroupsValue) Flatten(ctx context.Context, in *rafay.NodeGroup, stat
 	}
 	if in.VolumeEncrypted != nil {
 		v.VolumeEncrypted = types.BoolPointerValue(in.VolumeEncrypted)
+	} else {
+		v.VolumeEncrypted = types.BoolValue(false)
 	}
 	if in.VolumeKmsKeyID != "" {
 		v.VolumeKmsKeyId = types.StringValue(in.VolumeKmsKeyID)
@@ -143,6 +155,8 @@ func (v *NodeGroupsValue) Flatten(ctx context.Context, in *rafay.NodeGroup, stat
 	}
 	if in.EnableDetailedMonitoring != nil {
 		v.EnableDetailedMonitoring = types.BoolPointerValue(in.EnableDetailedMonitoring)
+	} else {
+		v.EnableDetailedMonitoring = types.BoolValue(false)
 	}
 	if in.InstanceType != "" {
 		v.InstanceType = types.StringValue(in.InstanceType)
@@ -510,6 +524,8 @@ func (v *InstancesDistributionValue) Flatten(ctx context.Context, in *rafay.Node
 	}
 	if in.CapacityRebalance != nil {
 		v.CapacityRebalance = types.BoolPointerValue(in.CapacityRebalance)
+	} else {
+		v.CapacityRebalance = types.BoolValue(false)
 	}
 
 	v.state = attr.ValueStateKnown
@@ -834,39 +850,63 @@ func (v *IamNodeGroupWithAddonPoliciesValue) Flatten(ctx context.Context, in *ra
 
 	if in.AWSLoadBalancerController != nil {
 		v.AlbIngress = types.BoolPointerValue(in.AWSLoadBalancerController)
+	} else {
+		v.AlbIngress = types.BoolValue(false)
 	}
 	if in.AppMesh != nil {
 		v.AppMesh = types.BoolPointerValue(in.AppMesh)
+	} else {
+		v.AppMesh = types.BoolValue(false)
 	}
 	if in.AppMeshPreview != nil {
 		v.AppMeshReview = types.BoolPointerValue(in.AppMeshPreview)
+	} else {
+		v.AppMeshReview = types.BoolValue(false)
 	}
 	if in.AutoScaler != nil {
 		v.AutoScaler = types.BoolPointerValue(in.AutoScaler)
+	} else {
+		v.AutoScaler = types.BoolValue(true)
 	}
 	if in.CertManager != nil {
 		v.CertManager = types.BoolPointerValue(in.CertManager)
+	} else {
+		v.CertManager = types.BoolValue(false)
 	}
 	if in.CloudWatch != nil {
 		v.CloudWatch = types.BoolPointerValue(in.CloudWatch)
+	} else {
+		v.CloudWatch = types.BoolValue(false)
 	}
 	if in.EBS != nil {
 		v.Ebs = types.BoolPointerValue(in.EBS)
+	} else {
+		v.Ebs = types.BoolValue(false)
 	}
 	if in.EFS != nil {
 		v.Efs = types.BoolPointerValue(in.EFS)
+	} else {
+		v.Efs = types.BoolValue(false)
 	}
 	if in.ExternalDNS != nil {
 		v.ExternalDns = types.BoolPointerValue(in.ExternalDNS)
+	} else {
+		v.ExternalDns = types.BoolValue(false)
 	}
 	if in.FSX != nil {
 		v.Fsx = types.BoolPointerValue(in.FSX)
+	} else {
+		v.Fsx = types.BoolValue(false)
 	}
 	if in.ImageBuilder != nil {
 		v.ImageBuilder = types.BoolPointerValue(in.ImageBuilder)
+	} else {
+		v.ImageBuilder = types.BoolValue(true)
 	}
 	if in.XRay != nil {
 		v.Xray = types.BoolPointerValue(in.XRay)
+	} else {
+		v.Xray = types.BoolValue(false)
 	}
 	v.state = attr.ValueStateKnown
 	return diags

--- a/internal/resource_eks_cluster/eks_cluster_resource_flatten_nodegroup_map.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_flatten_nodegroup_map.go
@@ -25,12 +25,18 @@ func (v *NodeGroupsMapValue) Flatten(ctx context.Context, in *rafay.NodeGroup, s
 	}
 	if in.DisableIMDSv1 != nil {
 		v.DisableImdsv1 = types.BoolPointerValue(in.DisableIMDSv1)
+	} else {
+		v.DisableImdsv1 = types.BoolValue(false)
 	}
 	if in.DisablePodIMDS != nil {
 		v.DisablePodsImds = types.BoolPointerValue(in.DisablePodIMDS)
+	} else {
+		v.DisablePodsImds = types.BoolValue(false)
 	}
 	if in.EFAEnabled != nil {
 		v.EfaEnabled = types.BoolPointerValue(in.EFAEnabled)
+	} else {
+		v.EfaEnabled = types.BoolValue(false)
 	}
 	if in.InstanceType != "" {
 		v.InstanceType = types.StringValue(in.InstanceType)
@@ -53,6 +59,8 @@ func (v *NodeGroupsMapValue) Flatten(ctx context.Context, in *rafay.NodeGroup, s
 	}
 	if in.PrivateNetworking != nil {
 		v.PrivateNetworking = types.BoolPointerValue(in.PrivateNetworking)
+	} else {
+		v.PrivateNetworking = types.BoolValue(false)
 	}
 	if in.Version != "" {
 		v.Version = types.StringValue(in.Version)
@@ -74,12 +82,16 @@ func (v *NodeGroupsMapValue) Flatten(ctx context.Context, in *rafay.NodeGroup, s
 	}
 	if in.EBSOptimized != nil {
 		v.EbsOptimized = types.BoolPointerValue(in.EBSOptimized)
+	} else {
+		v.EbsOptimized = types.BoolValue(false)
 	}
 	if in.VolumeName != "" {
 		v.VolumeName = types.StringValue(in.VolumeName)
 	}
 	if in.VolumeEncrypted != nil {
 		v.VolumeEncrypted = types.BoolPointerValue(in.VolumeEncrypted)
+	} else {
+		v.VolumeEncrypted = types.BoolValue(false)
 	}
 	if in.VolumeKmsKeyID != "" {
 		v.VolumeKmsKeyId = types.StringValue(in.VolumeKmsKeyID)
@@ -137,6 +149,8 @@ func (v *NodeGroupsMapValue) Flatten(ctx context.Context, in *rafay.NodeGroup, s
 	}
 	if in.EnableDetailedMonitoring != nil {
 		v.EnableDetailedMonitoring = types.BoolPointerValue(in.EnableDetailedMonitoring)
+	} else {
+		v.EnableDetailedMonitoring = types.BoolValue(false)
 	}
 	if in.InstanceType != "" {
 		v.InstanceType = types.StringValue(in.InstanceType)
@@ -441,39 +455,63 @@ func (v *IamNodeGroupWithAddonPolicies6Value) Flatten(ctx context.Context, in *r
 	}
 	if in.AWSLoadBalancerController != nil {
 		v.AlbIngress = types.BoolPointerValue(in.AWSLoadBalancerController)
+	} else {
+		v.AlbIngress = types.BoolValue(false)
 	}
 	if in.AppMesh != nil {
 		v.AppMesh = types.BoolPointerValue(in.AppMesh)
+	} else {
+		v.AppMesh = types.BoolValue(false)
 	}
 	if in.AppMeshPreview != nil {
 		v.AppMeshReview = types.BoolPointerValue(in.AppMeshPreview)
+	} else {
+		v.AppMeshReview = types.BoolValue(false)
 	}
 	if in.AutoScaler != nil {
 		v.AutoScaler = types.BoolPointerValue(in.AutoScaler)
+	} else {
+		v.AutoScaler = types.BoolValue(true)
 	}
 	if in.CertManager != nil {
 		v.CertManager = types.BoolPointerValue(in.CertManager)
+	} else {
+		v.CertManager = types.BoolValue(false)
 	}
 	if in.CloudWatch != nil {
 		v.CloudWatch = types.BoolPointerValue(in.CloudWatch)
+	} else {
+		v.CloudWatch = types.BoolValue(false)
 	}
 	if in.EBS != nil {
 		v.Ebs = types.BoolPointerValue(in.EBS)
+	} else {
+		v.Ebs = types.BoolValue(false)
 	}
 	if in.EFS != nil {
 		v.Efs = types.BoolPointerValue(in.EFS)
+	} else {
+		v.Efs = types.BoolValue(false)
 	}
 	if in.ExternalDNS != nil {
 		v.ExternalDns = types.BoolPointerValue(in.ExternalDNS)
+	} else {
+		v.ExternalDns = types.BoolValue(false)
 	}
 	if in.FSX != nil {
 		v.Fsx = types.BoolPointerValue(in.FSX)
+	} else {
+		v.Fsx = types.BoolValue(false)
 	}
 	if in.ImageBuilder != nil {
 		v.ImageBuilder = types.BoolPointerValue(in.ImageBuilder)
+	} else {
+		v.ImageBuilder = types.BoolValue(true)
 	}
 	if in.XRay != nil {
 		v.Xray = types.BoolPointerValue(in.XRay)
+	} else {
+		v.Xray = types.BoolValue(false)
 	}
 	v.state = attr.ValueStateKnown
 	return diags

--- a/internal/resource_eks_cluster/eks_cluster_resource_flatten_nodegroup_map.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_flatten_nodegroup_map.go
@@ -59,8 +59,6 @@ func (v *NodeGroupsMapValue) Flatten(ctx context.Context, in *rafay.NodeGroup, s
 	}
 	if in.PrivateNetworking != nil {
 		v.PrivateNetworking = types.BoolPointerValue(in.PrivateNetworking)
-	} else {
-		v.PrivateNetworking = types.BoolValue(false)
 	}
 	if in.Version != "" {
 		v.Version = types.StringValue(in.Version)
@@ -730,6 +728,8 @@ func (v *InstancesDistribution6Value) Flatten(ctx context.Context, in *rafay.Nod
 	}
 	if in.CapacityRebalance != nil {
 		v.CapacityRebalance = types.BoolPointerValue(in.CapacityRebalance)
+	} else {
+		v.CapacityRebalance = types.BoolValue(false)
 	}
 	v.state = attr.ValueStateKnown
 	return diags
@@ -852,9 +852,13 @@ func (v *SecurityGroups6Value) Flatten(ctx context.Context, in *rafay.NodeGroupS
 	}
 	if in.WithShared != nil {
 		v.WithShared = types.BoolPointerValue(in.WithShared)
+	} else {
+		v.WithShared = types.BoolValue(true)
 	}
 	if in.WithLocal != nil {
 		v.WithLocal = types.BoolPointerValue(in.WithLocal)
+	} else {
+		v.WithLocal = types.BoolValue(true)
 	}
 
 	if len(in.AttachIDs) > 0 {

--- a/internal/resource_eks_cluster/eks_cluster_resource_gen.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_gen.go
@@ -714,8 +714,6 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"max_pods_per_node": schema.Int64Attribute{
 										Optional: true,
-										Computed: true,
-										Default:  int64default.StaticInt64(0),
 									},
 									"max_size": schema.Int64Attribute{
 										Optional: true,
@@ -969,10 +967,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"volume_iops": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
 										MarkdownDescription: "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
-										Default:             int64default.StaticInt64(3000),
 									},
 									"volume_kms_key_id": schema.StringAttribute{
 										Optional:            true,
@@ -986,17 +982,13 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"volume_size": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The size of the EBS volumes attached to the nodes in this group, in GiB.",
 										MarkdownDescription: "The size of the EBS volumes attached to the nodes in this group, in GiB.",
-										Default:             int64default.StaticInt64(80),
 									},
 									"volume_throughput": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
 										MarkdownDescription: "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
-										Default:             int64default.StaticInt64(125),
 									},
 									"volume_type": schema.StringAttribute{
 										Optional:            true,
@@ -1370,7 +1362,7 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 										Optional: true,
 									},
 									"instance_type": schema.StringAttribute{
-										Required:            true,
+										Optional:            true,
 										Description:         "The type of EC2 instance to use for the nodes in this group.",
 										MarkdownDescription: "The type of EC2 instance to use for the nodes in this group.",
 									},
@@ -1399,14 +1391,12 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 												Computed:            true,
 												Description:         "base number of on-demand instances (non-negative).",
 												MarkdownDescription: "base number of on-demand instances (non-negative).",
-												Default:             int64default.StaticInt64(0),
 											},
 											"on_demand_percentage_above_base_capacity": schema.Int64Attribute{
 												Optional:            true,
 												Computed:            true,
 												Description:         "percentage of on-demand instances above base capacity (0-100).",
 												MarkdownDescription: "percentage of on-demand instances above base capacity (0-100).",
-												Default:             int64default.StaticInt64(100),
 											},
 											"spot_allocation_strategy": schema.StringAttribute{
 												Optional:            true,
@@ -1418,7 +1408,6 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 												Computed:            true,
 												Description:         "number of spot instance pools to use (1-20).",
 												MarkdownDescription: "number of spot instance pools to use (1-20).",
-												Default:             int64default.StaticInt64(2),
 											},
 										},
 										CustomType: InstancesDistribution6Type{
@@ -1475,8 +1464,6 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"max_pods_per_node": schema.Int64Attribute{
 										Optional: true,
-										Computed: true,
-										Default:  int64default.StaticInt64(0),
 									},
 									"max_size": schema.Int64Attribute{
 										Optional: true,
@@ -1671,10 +1658,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"volume_iops": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
 										MarkdownDescription: "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
-										Default:             int64default.StaticInt64(3000),
 									},
 									"volume_kms_key_id": schema.StringAttribute{
 										Optional:            true,
@@ -1688,17 +1673,13 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"volume_size": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The size of the EBS volumes attached to the nodes in this group, in GiB.",
 										MarkdownDescription: "The size of the EBS volumes attached to the nodes in this group, in GiB.",
-										Default:             int64default.StaticInt64(80),
 									},
 									"volume_throughput": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
 										MarkdownDescription: "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
-										Default:             int64default.StaticInt64(125),
 									},
 									"volume_type": schema.StringAttribute{
 										Optional:            true,
@@ -2861,8 +2842,6 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"max_pods_per_node": schema.Int64Attribute{
 										Optional: true,
-										Computed: true,
-										Default:  int64default.StaticInt64(0),
 									},
 									"max_size": schema.Int64Attribute{
 										Optional: true,
@@ -2930,10 +2909,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"volume_iops": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
 										MarkdownDescription: "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
-										Default:             int64default.StaticInt64(3000),
 									},
 									"volume_kms_key_id": schema.StringAttribute{
 										Optional:            true,
@@ -2947,17 +2924,13 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"volume_size": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The size of the EBS volumes attached to the nodes in this group, in GiB.",
 										MarkdownDescription: "The size of the EBS volumes attached to the nodes in this group, in GiB.",
-										Default:             int64default.StaticInt64(80),
 									},
 									"volume_throughput": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
 										MarkdownDescription: "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
-										Default:             int64default.StaticInt64(125),
 									},
 									"volume_type": schema.StringAttribute{
 										Optional:            true,
@@ -3572,7 +3545,7 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 										MarkdownDescription: "Prefix for the instance name.",
 									},
 									"instance_type": schema.StringAttribute{
-										Required:            true,
+										Optional:            true,
 										Description:         "The type of EC2 instance to use for the nodes in this group.",
 										MarkdownDescription: "The type of EC2 instance to use for the nodes in this group.",
 									},
@@ -3584,8 +3557,6 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"max_pods_per_node": schema.Int64Attribute{
 										Optional: true,
-										Computed: true,
-										Default:  int64default.StaticInt64(0),
 									},
 									"max_size": schema.Int64Attribute{
 										Optional: true,
@@ -3657,10 +3628,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"volume_iops": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
 										MarkdownDescription: "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
-										Default:             int64default.StaticInt64(3000),
 									},
 									"volume_kms_key_id": schema.StringAttribute{
 										Optional:            true,
@@ -3674,17 +3643,13 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"volume_size": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The size of the EBS volumes attached to the nodes in this group, in GiB.",
 										MarkdownDescription: "The size of the EBS volumes attached to the nodes in this group, in GiB.",
-										Default:             int64default.StaticInt64(80),
 									},
 									"volume_throughput": schema.Int64Attribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
 										MarkdownDescription: "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
-										Default:             int64default.StaticInt64(125),
 									},
 									"volume_type": schema.StringAttribute{
 										Optional:            true,
@@ -3994,14 +3959,12 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 													Computed:            true,
 													Description:         "base number of on-demand instances (non-negative).",
 													MarkdownDescription: "base number of on-demand instances (non-negative).",
-													Default:             int64default.StaticInt64(0),
 												},
 												"on_demand_percentage_above_base_capacity": schema.Int64Attribute{
 													Optional:            true,
 													Computed:            true,
 													Description:         "percentage of on-demand instances above base capacity (0-100).",
 													MarkdownDescription: "percentage of on-demand instances above base capacity (0-100).",
-													Default:             int64default.StaticInt64(100),
 												},
 												"spot_allocation_strategy": schema.StringAttribute{
 													Optional:            true,
@@ -4013,7 +3976,6 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 													Computed:            true,
 													Description:         "number of spot instance pools to use (1-20).",
 													MarkdownDescription: "number of spot instance pools to use (1-20).",
-													Default:             int64default.StaticInt64(2),
 												},
 											},
 											CustomType: InstancesDistributionType{

--- a/internal/resource_eks_cluster/eks_cluster_resource_gen.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_gen.go
@@ -820,10 +820,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"private_networking": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Enable private networking for the node group.",
 										MarkdownDescription: "Enable private networking for the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"security_groups": schema.SingleNestedAttribute{
 										Attributes: map[string]schema.Attribute{
@@ -1388,13 +1386,11 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 											},
 											"on_demand_base_capacity": schema.Int64Attribute{
 												Optional:            true,
-												Computed:            true,
 												Description:         "base number of on-demand instances (non-negative).",
 												MarkdownDescription: "base number of on-demand instances (non-negative).",
 											},
 											"on_demand_percentage_above_base_capacity": schema.Int64Attribute{
 												Optional:            true,
-												Computed:            true,
 												Description:         "percentage of on-demand instances above base capacity (0-100).",
 												MarkdownDescription: "percentage of on-demand instances above base capacity (0-100).",
 											},
@@ -1405,7 +1401,6 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 											},
 											"spot_instance_pools": schema.Int64Attribute{
 												Optional:            true,
-												Computed:            true,
 												Description:         "number of spot instance pools to use (1-20).",
 												MarkdownDescription: "number of spot instance pools to use (1-20).",
 											},
@@ -1503,10 +1498,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"private_networking": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Enable private networking for the node group.",
 										MarkdownDescription: "Enable private networking for the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"security_groups": schema.SingleNestedAttribute{
 										Attributes: map[string]schema.Attribute{
@@ -2871,10 +2864,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"private_networking": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Enable private networking for the node group.",
 										MarkdownDescription: "Enable private networking for the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"spot": schema.BoolAttribute{
 										Optional:            true,
@@ -3586,10 +3577,8 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 									},
 									"private_networking": schema.BoolAttribute{
 										Optional:            true,
-										Computed:            true,
 										Description:         "Enable private networking for the node group.",
 										MarkdownDescription: "Enable private networking for the node group.",
-										Default:             booldefault.StaticBool(false),
 									},
 									"subnet_cidr": schema.StringAttribute{
 										Optional:            true,
@@ -3956,13 +3945,11 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 												},
 												"on_demand_base_capacity": schema.Int64Attribute{
 													Optional:            true,
-													Computed:            true,
 													Description:         "base number of on-demand instances (non-negative).",
 													MarkdownDescription: "base number of on-demand instances (non-negative).",
 												},
 												"on_demand_percentage_above_base_capacity": schema.Int64Attribute{
 													Optional:            true,
-													Computed:            true,
 													Description:         "percentage of on-demand instances above base capacity (0-100).",
 													MarkdownDescription: "percentage of on-demand instances above base capacity (0-100).",
 												},
@@ -3973,7 +3960,6 @@ func EksClusterResourceSchema(ctx context.Context) schema.Schema {
 												},
 												"spot_instance_pools": schema.Int64Attribute{
 													Optional:            true,
-													Computed:            true,
 													Description:         "number of spot instance pools to use (1-20).",
 													MarkdownDescription: "number of spot instance pools to use (1-20).",
 												},

--- a/internal/resource_eks_cluster/eks_cluster_resource_spec.json
+++ b/internal/resource_eks_cluster/eks_cluster_resource_spec.json
@@ -550,10 +550,7 @@
                                                     "name": "private_networking",
                                                     "bool": {
                                                         "description": "Enable private networking for the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 {
@@ -1129,21 +1126,21 @@
                                                                 {
                                                                     "name": "on_demand_base_capacity",
                                                                     "int64": {
-                                                                        "computed_optional_required": "computed_optional",
+                                                                        "computed_optional_required": "optional",
                                                                         "description": "base number of on-demand instances (non-negative)."
                                                                     }
                                                                 },
                                                                 {
                                                                     "name": "on_demand_percentage_above_base_capacity",
                                                                     "int64": {
-                                                                        "computed_optional_required": "computed_optional",
+                                                                        "computed_optional_required": "optional",
                                                                         "description": "percentage of on-demand instances above base capacity (0-100)."
                                                                     }
                                                                 },
                                                                 {
                                                                     "name": "spot_instance_pools",
                                                                     "int64": {
-                                                                        "computed_optional_required": "computed_optional",
+                                                                        "computed_optional_required": "optional",
                                                                         "description": "number of spot instance pools to use (1-20)."
                                                                     }
                                                                 },
@@ -1448,10 +1445,7 @@
                                                     "name": "private_networking",
                                                     "bool": {
                                                         "description": "Enable private networking for the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 {
@@ -2421,10 +2415,7 @@
                                                     "name": "private_networking",
                                                     "bool": {
                                                         "description": "Enable private networking for the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 {
@@ -3019,21 +3010,21 @@
                                                                 {
                                                                     "name": "on_demand_base_capacity",
                                                                     "int64": {
-                                                                        "computed_optional_required": "computed_optional",
+                                                                        "computed_optional_required": "optional",
                                                                         "description": "base number of on-demand instances (non-negative)."
                                                                     }
                                                                 },
                                                                 {
                                                                     "name": "on_demand_percentage_above_base_capacity",
                                                                     "int64": {
-                                                                        "computed_optional_required": "computed_optional",
+                                                                        "computed_optional_required": "optional",
                                                                         "description": "percentage of on-demand instances above base capacity (0-100)."
                                                                     }
                                                                 },
                                                                 {
                                                                     "name": "spot_instance_pools",
                                                                     "int64": {
-                                                                        "computed_optional_required": "computed_optional",
+                                                                        "computed_optional_required": "optional",
                                                                         "description": "number of spot instance pools to use (1-20)."
                                                                     }
                                                                 },
@@ -5124,10 +5115,7 @@
                                                     "name": "private_networking",
                                                     "bool": {
                                                         "description": "Enable private networking for the node group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": false
-                                                        }
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 {

--- a/internal/resource_eks_cluster/eks_cluster_resource_spec.json
+++ b/internal/resource_eks_cluster/eks_cluster_resource_spec.json
@@ -481,7 +481,7 @@
                                                 {
                                                     "name": "instance_type",
                                                     "string": {
-                                                        "computed_optional_required": "required",
+                                                        "computed_optional_required": "optional",
                                                         "description": "The type of EC2 instance to use for the nodes in this group."
                                                     }
                                                 },
@@ -512,13 +512,10 @@
                                                 {
                                                     "name": "max_pods_per_node",
                                                     "int64": {
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 0
-                                                        } 
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
-                                                
+                                              
                                                 {
                                                     "name": "disable_imdsv1",
                                                     "bool": {
@@ -563,30 +560,21 @@
                                                     "name": "volume_iops",
                                                     "int64": {
                                                         "description": "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 3000
-                                                        }
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 {
                                                     "name": "volume_size",
                                                     "int64": {
                                                         "description": "The size of the EBS volumes attached to the nodes in this group, in GiB.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 80
-                                                        }
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 {
                                                     "name": "volume_throughput",
                                                     "int64": {
                                                         "description": "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 125
-                                                        }
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 {
@@ -1142,19 +1130,13 @@
                                                                     "name": "on_demand_base_capacity",
                                                                     "int64": {
                                                                         "computed_optional_required": "computed_optional",
-                                                                        "description": "base number of on-demand instances (non-negative).",
-                                                                        "default": {
-                                                                            "static": 0
-                                                                        }
+                                                                        "description": "base number of on-demand instances (non-negative)."
                                                                     }
                                                                 },
                                                                 {
                                                                     "name": "on_demand_percentage_above_base_capacity",
                                                                     "int64": {
                                                                         "computed_optional_required": "computed_optional",
-                                                                        "default": {
-                                                                            "static": 100
-                                                                        },
                                                                         "description": "percentage of on-demand instances above base capacity (0-100)."
                                                                     }
                                                                 },
@@ -1162,9 +1144,6 @@
                                                                     "name": "spot_instance_pools",
                                                                     "int64": {
                                                                         "computed_optional_required": "computed_optional",
-                                                                        "default": {
-                                                                            "static": 2
-                                                                        },
                                                                         "description": "number of spot instance pools to use (1-20)."
                                                                     }
                                                                 },
@@ -1431,10 +1410,7 @@
                                                 {
                                                     "name": "max_pods_per_node",
                                                     "int64": {
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 0
-                                                        }    
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 
@@ -1482,30 +1458,21 @@
                                                     "name": "volume_iops",
                                                     "int64": {
                                                         "description": "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 3000
-                                                        }
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 {
                                                     "name": "volume_size",
                                                     "int64": {
                                                         "description": "The size of the EBS volumes attached to the nodes in this group, in GiB.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 80
-                                                        }
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 {
                                                     "name": "volume_throughput",
                                                     "int64": {
                                                         "description": "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 125
-                                                        }
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 {
@@ -2385,7 +2352,7 @@
                                                 {
                                                     "name": "instance_type",
                                                     "string": {
-                                                        "computed_optional_required": "required",
+                                                        "computed_optional_required": "optional",
                                                         "description": "The type of EC2 instance to use for the nodes in this group."
                                                     }
                                                 },
@@ -2416,10 +2383,7 @@
                                                 {
                                                     "name": "max_pods_per_node",
                                                     "int64": {
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 0
-                                                        } 
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 
@@ -2467,30 +2431,21 @@
                                                     "name": "volume_iops",
                                                     "int64": {
                                                         "description": "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 3000
-                                                        }
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 {
                                                     "name": "volume_size",
                                                     "int64": {
                                                         "description": "The size of the EBS volumes attached to the nodes in this group, in GiB.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 80
-                                                        }
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 {
                                                     "name": "volume_throughput",
                                                     "int64": {
                                                         "description": "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 125
-                                                        }
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 {
@@ -3065,19 +3020,13 @@
                                                                     "name": "on_demand_base_capacity",
                                                                     "int64": {
                                                                         "computed_optional_required": "computed_optional",
-                                                                        "description": "base number of on-demand instances (non-negative).",
-                                                                        "default": {
-                                                                            "static": 0
-                                                                        }
+                                                                        "description": "base number of on-demand instances (non-negative)."
                                                                     }
                                                                 },
                                                                 {
                                                                     "name": "on_demand_percentage_above_base_capacity",
                                                                     "int64": {
                                                                         "computed_optional_required": "computed_optional",
-                                                                        "default": {
-                                                                            "static": 100
-                                                                        },
                                                                         "description": "percentage of on-demand instances above base capacity (0-100)."
                                                                     }
                                                                 },
@@ -3085,9 +3034,6 @@
                                                                     "name": "spot_instance_pools",
                                                                     "int64": {
                                                                         "computed_optional_required": "computed_optional",
-                                                                        "default": {
-                                                                            "static": 2
-                                                                        },
                                                                         "description": "number of spot instance pools to use (1-20)."
                                                                     }
                                                                 },
@@ -5141,10 +5087,7 @@
                                                 {
                                                     "name": "max_pods_per_node",
                                                     "int64": {
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 0
-                                                        }   
+                                                        "computed_optional_required": "optional" 
                                                     }
                                                 },
                                                 {
@@ -5191,30 +5134,21 @@
                                                     "name": "volume_iops",
                                                     "int64": {
                                                         "description": "The number of IOPS to provision for the EBS volumes attached to the nodes in this group.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 3000
-                                                        }
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 {
                                                     "name": "volume_size",
                                                     "int64": {
                                                         "description": "The size of the EBS volumes attached to the nodes in this group, in GiB.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 80
-                                                        }
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 {
                                                     "name": "volume_throughput",
                                                     "int64": {
                                                         "description": "The throughput of the EBS volumes attached to the nodes in this group, in MiB/s.",
-                                                        "computed_optional_required": "computed_optional",
-                                                        "default": {
-                                                            "static": 125
-                                                        }
+                                                        "computed_optional_required": "optional"
                                                     }
                                                 },
                                                 {

--- a/rafay/eks_config.go
+++ b/rafay/eks_config.go
@@ -599,7 +599,7 @@ type NodeGroup struct {
 	// networking](/usage/vpc-networking/#use-private-subnets-for-initial-nodegroup)
 	// for nodegroup
 	// +optional
-	PrivateNetworking *bool `yaml:"privateNetworking"`
+	PrivateNetworking *bool `yaml:"privateNetworking,omitempty"`
 	// Applied to the Autoscaling Group and to the EC2 instances (unmanaged),
 	// Applied to the EKS Nodegroup resource and to the EC2 instances (managed)
 	// +optional
@@ -787,7 +787,7 @@ type NodeGroupBase struct {
 	// networking](/usage/vpc-networking/#use-private-subnets-for-initial-nodegroup)
 	// for nodegroup
 	// +optional
-	PrivateNetworking *bool `yaml:"privateNetworking"`
+	PrivateNetworking *bool `yaml:"privateNetworking,omitempty"`
 	// Applied to the Autoscaling Group and to the EC2 instances (unmanaged),
 	// Applied to the EKS Nodegroup resource and to the EC2 instances (managed)
 	// +optional
@@ -1115,7 +1115,7 @@ type ManagedNodeGroup struct {
 	// networking](/usage/vpc-networking/#use-private-subnets-for-initial-nodegroup)
 	// for nodegroup
 	// +optional
-	PrivateNetworking *bool `yaml:"privateNetworking"`
+	PrivateNetworking *bool `yaml:"privateNetworking,omitempty"`
 	// Applied to the Autoscaling Group and to the EC2 instances (unmanaged),
 	// Applied to the EKS Nodegroup resource and to the EC2 instances (managed)
 	// +optional


### PR DESCRIPTION
https://rafaysystems.atlassian.net/browse/RC-51061
