### PR TITLE
RC-52776: Fix AutoModeConfigValue.Flatten never marking value as Known

### DIFF
--- a/internal/resource_eks_cluster/eks_cluster_resource_flatten.go
+++ b/internal/resource_eks_cluster/eks_cluster_resource_flatten.go
@@ -760,6 +760,7 @@ func (v *AutoModeConfigValue) Flatten(ctx context.Context, in *rafay.EKSAutoMode
 	}
 	v.NodePools = nodePools
 
+	v.state = attr.ValueStateKnown
 	return diags
 }
 


### PR DESCRIPTION
## Summary
- `terraform plan` shows a permanent, non-clearing `+ auto_mode_config` diff on EKS Auto Mode clusters, even when the backend is confirmed to be serving fully correct data (verified via direct API calls and via the provider's own decoded struct in debug logs).
- Root cause: `AutoModeConfigValue.Flatten` (`internal/resource_eks_cluster/eks_cluster_resource_flatten.go`) correctly populates `Enabled`/`NodePools`/`NodeRoleArn` but never sets `v.state = attr.ValueStateKnown` — unlike every structurally-identical sibling flatten function in the same file (`ZonalShiftConfigValue.Flatten`, `DeleteProtectionConfigValue.Flatten`, `AutoZonalShiftConfigValue.Flatten`), all of which do.
- `v.state` is internal bookkeeping the terraform-plugin-framework uses to track whether an object value is Known/Null/Unknown, independent of the actual field data. Leaving it unset means the framework treats the whole `auto_mode_config` object as not-Known when computing the plan diff — so it always shows as being added from scratch, regardless of backend correctness.

## Fix
One line: set `v.state = attr.ValueStateKnown` at the end of `AutoModeConfigValue.Flatten`, matching the existing pattern.

## Verification
- Confirmed the bug reproduces on the actual tagged release currently in use (`v1.1.66`), not just an unreleased branch.
- Built this fix locally as `v1.1.67`, installed to the local provider filesystem mirror, re-ran `terraform init`/`terraform plan` against a live EKS Auto Mode cluster (same cluster, same state, only the provider binary swapped):
  - Before fix (`v1.1.66`): `terraform plan` always showed `+ auto_mode_config { ... }`.
  - After fix (`v1.1.67`): `terraform plan` → `No changes. Your infrastructure matches the configuration.` — repeated 3x, stable every time.

This is one of two required fixes for RC-52776 — the other (edgesrv, [PR #2188](https://github.com/RafaySystems/edgesrv/pull/2188)) fixes a separate backend cache-staleness bug. Both are needed together; either alone leaves the diff in place.

## Test plan
- [x] `go build ./internal/resource_eks_cluster/...` passes
- [x] Verified locally against a live cluster: diff present before fix, gone after fix, stable across repeated `terraform plan` runs
- [ ] Confirm `zonal_shift_config`/`delete_protection_config` behavior is unaffected (no changes to those flatten functions)